### PR TITLE
Bump CI actions to latest majors (Node 24 compat)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: extractions/setup-just@v2
-      - uses: actions/setup-node@v4
+      - uses: extractions/setup-just@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: Setup dev environment
@@ -53,11 +53,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: extractions/setup-just@v2
-      - uses: actions/setup-node@v4
+      - uses: extractions/setup-just@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: Setup dev environment
@@ -88,8 +88,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: Install dependencies
@@ -102,12 +102,12 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v6
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
- Bump all GitHub Actions to their latest major versions ahead of the 2026-06-02 Node 24 runner deadline
- checkout v4→v6, setup-node v4→v6, setup-just v2→v4, login-action v3→v4, build-push-action v5→v7
- No workflow logic changes — version bumps only

## Test plan
- [ ] test-mongo job green
- [ ] test-postgres job green
- [ ] lint job green
- [ ] docker job skipped (only runs on master push — expected)