### PR TITLE
fix(api-server): lazy-require backloop.dev (devDependency, not in pro…

### DIFF
--- a/components/api-server/src/server.js
+++ b/components/api-server/src/server.js
@@ -10,7 +10,6 @@ const { getApplication } = require('api-server/src/application');
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
-const recLaOptionsAsync = require('backloop.dev').httpsOptionsAsync;
 const { testMessaging } = require('messages');
 const { pubsub } = require('messages');
 const { getUsersRepository } = require('business/src/users');
@@ -57,6 +56,10 @@ class Server {
       hostname: null
     };
     if (config.get('http:ssl:backloop.dev')) { // SSL is used in openSource version
+      // Lazy require: backloop.dev is a devDependency, not installed in
+      // production images (Dockerfile does `npm install --omit=dev`).
+      // Only load when actually wired into config.
+      const recLaOptionsAsync = require('backloop.dev').httpsOptionsAsync;
       await new Promise((resolve, reject) => {
         recLaOptionsAsync((err, recLaOptions) => {
           if (err) return reject(err);


### PR DESCRIPTION
…d image)

components/api-server/src/server.js had an eager top-level `require('backloop.dev')` even though backloop.dev is a devDependency and the Dockerfile runs `npm install --omit=dev`. Result: every production boot threw MODULE_NOT_FOUND before any config was read.

Move the require inside the `if (config.get('http:ssl:backloop.dev'))` branch so production images that never wire backloop.dev never look for it on disk. Local-dev paths that DO set http.ssl.backloop.dev=true are unchanged — devDependencies are installed and the require resolves.

Surfaced 2026-04-29 deploying upstream-master onto a Dockerfile prod image (single-core, dnsLess=false, native HTTPS via ACME).