### PR TITLE
fix(mfa): replace removed uuid dep with node:crypto.randomUUID

### DIFF
--- a/components/business/src/mfa/Profile.js
+++ b/components/business/src/mfa/Profile.js
@@ -5,7 +5,7 @@
  * Refer to LICENSE file
  */
 
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID: uuidv4 } = require('node:crypto');
 
 /**
  * MFA profile model: the per-user state stored in the user's private profile

--- a/components/business/src/mfa/SessionStore.js
+++ b/components/business/src/mfa/SessionStore.js
@@ -5,7 +5,7 @@
  * Refer to LICENSE file
  */
 
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID: uuidv4 } = require('node:crypto');
 
 /**
  * In-memory MFA session store.


### PR DESCRIPTION
components/business/src/mfa/{Profile,SessionStore}.js still required the uuid package (`v4`), but Plan 52 cleanup dropped uuid from package.json without replacing these two call sites. Production boot crashes MODULE_NOT_FOUND on first MFA-touching require chain (api-server/methods/auth/login → mfa).

`crypto.randomUUID()` is a node-native UUID v4 generator — drop-in replacement, same string format, no dep needed. Aliased to `uuidv4` to keep the local call sites unchanged.