### PR TITLE
fix(treeUtils): flattenTree() must preserve parentId on flat input

### DIFF
--- a/components/utils/src/treeUtils.js
+++ b/components/utils/src/treeUtils.js
@@ -152,7 +152,18 @@ exports.flattenTree = function (array) {
 function flattenRecursive (originalArray, parentId, resultArray) {
   originalArray.forEach(function (item) {
     const clone = structuredClone(item);
-    clone.parentId = parentId;
+    // When recursing into a parent's `children` array, the tree position
+    // is authoritative — overwrite parentId with the parent's id.
+    // At the root call (parentId === null), preserve any pre-existing
+    // parentId on the item, defaulting to null when neither is set.
+    // This makes flattenTree() idempotent on already-flat input
+    // (e.g. backup-restore pushes flat streams with parentId already set;
+    // without this, every parentId was silently nuked).
+    if (parentId !== null) {
+      clone.parentId = parentId;
+    } else if (clone.parentId === undefined) {
+      clone.parentId = null;
+    }
     resultArray.push(clone);
     if (clone.hasOwnProperty('children')) {
       flattenRecursive(clone.children, clone.id, resultArray);

--- a/components/utils/test/treeUtils.test.js
+++ b/components/utils/test/treeUtils.test.js
@@ -110,6 +110,40 @@ describe('[TRUT] tree utils', function () {
     it('[OVJM] must throw an error if the object in argument is not an array', function () {
       assert.throws(() => { treeUtils.flattenTree(testTree[0]); });
     });
+
+    it('[FL8T] must preserve existing parentId on already-flat input (idempotence)', function () {
+      // Restore-from-backup feeds flattenTree() flat arrays whose items
+      // already carry a parentId. Before the fix, the root recursion
+      // overwrote every parentId with `null` because flattenTree() called
+      // flattenRecursive with parentId=null.
+      const res = treeUtils.flattenTree(testArray);
+      assert.deepStrictEqual(res, testArray);
+      assert.notStrictEqual(res[0], testArray[0], 'should not return the original objects but copies instead');
+    });
+
+    it('[FL8U] must default parentId=null on items without one (root call)', function () {
+      const flat = [{ id: 'a' }, { id: 'b' }];
+      const res = treeUtils.flattenTree(flat);
+      assert.deepStrictEqual(res, [
+        { id: 'a', parentId: null },
+        { id: 'b', parentId: null }
+      ]);
+    });
+
+    it('[FL8V] children-array tree position must override any stale parentId on a child', function () {
+      // Mixed input: tree-shaped (children-bearing) where a child has a
+      // stale parentId. The tree position is authoritative — child's
+      // parentId becomes the parent's id regardless of any stale value.
+      const mixed = [{
+        id: 'root',
+        children: [{ id: 'kid', parentId: 'wrong-stale-id' }]
+      }];
+      const res = treeUtils.flattenTree(mixed);
+      assert.deepStrictEqual(res, [
+        { id: 'root', parentId: null },
+        { id: 'kid', parentId: 'root' }
+      ]);
+    });
   });
 
   describe('[TU03] findInTree()', function () {

--- a/storages/shared/treeUtils.js
+++ b/storages/shared/treeUtils.js
@@ -152,7 +152,18 @@ exports.flattenTree = function (array) {
 function flattenRecursive (originalArray, parentId, resultArray) {
   originalArray.forEach(function (item) {
     const clone = structuredClone(item);
-    clone.parentId = parentId;
+    // When recursing into a parent's `children` array, the tree position
+    // is authoritative — overwrite parentId with the parent's id.
+    // At the root call (parentId === null), preserve any pre-existing
+    // parentId on the item, defaulting to null when neither is set.
+    // This makes flattenTree() idempotent on already-flat input
+    // (e.g. backup-restore pushes flat streams with parentId already set;
+    // without this, every parentId was silently nuked).
+    if (parentId !== null) {
+      clone.parentId = parentId;
+    } else if (clone.parentId === undefined) {
+      clone.parentId = null;
+    }
     resultArray.push(clone);
     if (clone.hasOwnProperty('children')) {
       flattenRecursive(clone.children, clone.id, resultArray);


### PR DESCRIPTION
flattenRecursive() unconditionally overwrote `clone.parentId = parentId` on every node. At the root call (parentId === null), this nuked any pre-existing parentId on items — silently breaking restore-from-backup, which feeds flat arrays of streams with parentId already set.

Reproduction: backup a v1 tree of streams, restore into v2 Postgres, then SELECT count(*) FROM streams WHERE parent_id IS NOT NULL → 0, even though the JSON-on-disk has parentId on every non-root stream.

Fix: only force parentId at the recursion-into-children frame; at the root call, preserve any pre-existing parentId, defaulting to null when the item has none. flattenTree() is now idempotent on already-flat input, which is the contract callers from RestoreOrchestrator.streams implicitly rely on.

Tree-position authoritativeness for children is preserved — a child in a parent's `children` array gets the parent's id regardless of any stale parentId it carries, matching the previous behaviour.

Three regression tests added in components/utils/test/treeUtils.test.js (FL8T idempotence, FL8U default-null, FL8V tree-position-wins). treeUtils.js is duplicated in storages/shared/ and components/utils/src/ (byte-identical) — both are updated.