### PR TITLE
fix(pg): nest jsonb_set for multi-key dotted-path $inc

### DIFF
--- a/CHANGELOG-v2-back.md
+++ b/CHANGELOG-v2-back.md
@@ -1,5 +1,10 @@
 # Changelog - Internal (no API impact)
 
+## PG `$inc` JSONB-path collision — `multiple assignments to same column`
+
+- **FIX** `storages/engines/postgresql/src/user/BaseStoragePG.js` — `_buildUpdateClauses` `$inc` loop emitted one `SET col = jsonb_set(...)` clause per dotted-path entry. When a single update contained ≥2 entries sharing the same top-level column (e.g. `$inc: { 'calls.events:get': 1, 'calls.accesses:get': 1 }`, produced by every batched API call when `accessTracking.isActive: true`), Postgres rejected the UPDATE with `multiple assignments to same column "calls"`. Per-method counters were silently dropped (the storage error was caught + logged by `updateAccessUsageStats.js` after the API response had already returned 200). Fix groups dotted-path `$inc` entries by top-key and emits ONE nested `jsonb_set(jsonb_set(..., k1, v1), k2, v2)` clause per column. Each nested call reads the original column value (`col->>$key`), preserving Mongo `$inc` disjoint-paths semantics.
+- **TEST** new `[BTRK]` regression in `components/api-server/test/root-seq.test.js`: issues a real batched `POST /<username>` with `events.get` + `accesses.get` and asserts both per-method counters move (and by the same delta). Pre-fix the assertion fails because the SQL crashes and counters stay at baseline.
+
 ## Audit syslog transport — error listener prevents worker crash on missing socket
 
 - **FIX** `components/audit/src/syslog/Syslog.js` — the `winston-syslog` transport's underlying `unix-dgram` socket emits `'error'` on the first send when the configured socket path doesn't exist (typical containerized deploy with no `/dev/log`). `winston-transport` extends `stream.Writable`, and `Writable.emit('error', err)` with no listener throws synchronously → worker exits code 7 → cluster master recycles → user-visible: registration row landed in `users_index` but the auth poll on `core-<id>.<domain>/reg/access/<key>` times out with no token issued. Now `transport.on('error', err => logger.warn('audit syslog dropped', err))` so audit emits become best-effort observability instead of a load-bearing path.

--- a/components/api-server/test/root-seq.test.js
+++ b/components/api-server/test/root-seq.test.js
@@ -286,6 +286,54 @@ describe('[ROOT] root', function () {
       const exposed = _.find(res.body.accesses, { token: personalAccessToken });
       assert.ok(exposed.calls == null);
     });
+
+    it('[BTRK] trackingFunctions must increment per-method counters when ≥2 distinct methods land in the same batch call (PG: regression for "multiple assignments to same column \\"calls\\"")', async function () {
+      const findOneAsync = promisify((u, query, opts, cb) =>
+        helpers.dependencies.storage.user.accesses.findOne(u, query, opts, cb));
+      // Wait for prior tests' fire-and-forget tracking writes to settle so
+      // baseline doesn't shift mid-test.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      const baseline = await findOneAsync(user, { token: personalAccessToken }, null);
+      const baselineEventsGet = baseline.calls?.['events:get'] ?? 0;
+      const baselineAccessesGet = baseline.calls?.['accesses:get'] ?? 0;
+
+      const res = await server.request()
+        .post('/' + username)
+        .set('Authorization', personalAccessToken)
+        .send([
+          { method: 'events.get', params: { limit: 1 } },
+          { method: 'accesses.get', params: {} }
+        ]);
+      assert.strictEqual(res.status, 200);
+      assert.ok(Array.isArray(res.body.results));
+
+      // Fire-and-forget update: trackingFunctions calls next() before persisting.
+      // Re-poll until both counters move (or fail after a short window).
+      // Pre-fix bug: the PG `$inc` dotted-path loop emitted one SET clause per
+      // entry against the same `calls` column, raising
+      // "multiple assignments to same column" — the storage error was caught +
+      // logged, leaving both counters at baseline. Post-fix: counters do move.
+      // We assert that BOTH counters move and by the same amount (the api-server
+      // batch fixture may fire trackingFunctions more than once per request,
+      // so we don't pin to exactly +1; what matters is the SQL didn't crash
+      // and both keys were updated symmetrically).
+      const deadline = Date.now() + 1000;
+      let updated;
+      while (Date.now() < deadline) {
+        updated = await findOneAsync(user, { token: personalAccessToken }, null);
+        if ((updated.calls?.['events:get'] ?? 0) > baselineEventsGet &&
+            (updated.calls?.['accesses:get'] ?? 0) > baselineAccessesGet) break;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      const eventsDelta = (updated.calls?.['events:get'] ?? 0) - baselineEventsGet;
+      const accessesDelta = (updated.calls?.['accesses:get'] ?? 0) - baselineAccessesGet;
+      assert.ok(eventsDelta > 0,
+        `calls.events:get did not move (delta=${eventsDelta}); pre-fix the multi-key SQL crashed and the counters stayed at baseline`);
+      assert.ok(accessesDelta > 0,
+        `calls.accesses:get did not move (delta=${accessesDelta}); pre-fix the multi-key SQL crashed and the counters stayed at baseline`);
+      assert.strictEqual(eventsDelta, accessesDelta,
+        `both counters must move by the same amount (events:get +${eventsDelta}, accesses:get +${accessesDelta}); divergence would indicate one key was lost in the nested jsonb_set`);
+    });
   });
 
   describe('[RT03] OPTIONS /', function () {

--- a/storages/engines/postgresql/src/user/BaseStoragePG.js
+++ b/storages/engines/postgresql/src/user/BaseStoragePG.js
@@ -589,27 +589,42 @@ class BaseStoragePG {
       unsetClauses.push(`${col} = NULL`);
     }
 
-    // $inc
+    // $inc — group dotted-path entries by topKey so multiple JSONB-path
+    // increments on the same column produce ONE nested jsonb_set clause.
+    // Postgres rejects `SET col = …, col = …` ("multiple assignments to same
+    // column"), which is exactly what batched API calls produce when
+    // accessTracking is on (e.g. $inc: { 'calls.events:get': 1, 'calls.accesses:get': 1 }).
+    const dottedByTopKey = {};
+    const bareInc = [];
     for (const [k, v] of Object.entries($inc)) {
       if (k.includes('.')) {
-        // JSONB path increment: 'calls.events:get' → jsonb_set on 'calls' column
         const [topKey, ...rest] = k.split('.');
-        const snakeCol = this.toCol(topKey);
-        const jsonbKey = rest.join('.');
-        // jsonb_set(COALESCE(col, '{}'), '{key}', to_jsonb(COALESCE((col->>key)::numeric, 0) + val))
-        incClauses.push(
-          `${snakeCol} = jsonb_set(COALESCE(${snakeCol}, '{}'::jsonb), ` +
-          `ARRAY[$${idx}]::text[], ` +
-          `to_jsonb(COALESCE((${snakeCol}->>$${idx})::numeric, 0) + $${idx + 1}))`
-        );
+        if (dottedByTopKey[topKey] == null) dottedByTopKey[topKey] = [];
+        dottedByTopKey[topKey].push([rest.join('.'), v]);
+      } else {
+        bareInc.push([k, v]);
+      }
+    }
+    for (const [topKey, entries] of Object.entries(dottedByTopKey)) {
+      const snakeCol = this.toCol(topKey);
+      // Nest jsonb_set: each call wraps the previous expression. Each one reads
+      // (snakeCol->>$key) from the ORIGINAL column (not the partially-built
+      // expression) — preserves Mongo $inc disjoint-paths semantics.
+      let expr = `COALESCE(${snakeCol}, '{}'::jsonb)`;
+      for (const [jsonbKey, v] of entries) {
+        expr =
+          `jsonb_set(${expr}, ARRAY[$${idx}]::text[], ` +
+          `to_jsonb(COALESCE((${snakeCol}->>$${idx})::numeric, 0) + $${idx + 1}))`;
         params.push(jsonbKey, v);
         idx += 2;
-      } else {
-        const col = this.toCol(k);
-        incClauses.push(`${col} = COALESCE(${col}, 0) + $${idx}`);
-        params.push(v);
-        idx++;
       }
+      incClauses.push(`${snakeCol} = ${expr}`);
+    }
+    for (const [k, v] of bareInc) {
+      const col = this.toCol(k);
+      incClauses.push(`${col} = COALESCE(${col}, 0) + $${idx}`);
+      params.push(v);
+      idx++;
     }
 
     // $min


### PR DESCRIPTION
## Summary

PG storage `_buildUpdateClauses` `$inc` loop emitted one SET clause per dotted-path entry → `multiple assignments to same column "calls"` whenever a single update had ≥2 entries sharing the same top-level column. Hit by every batched API call when `accessTracking.isActive: true`.

Group dotted-path `$inc` entries by top-key, emit ONE nested `jsonb_set(jsonb_set(..., k1, v1), k2, v2)` clause per column. Each nested call reads from the original column value (`col->>$key`), preserving Mongo `$inc` disjoint-paths semantics.

## Production trigger

Surfaced via NewRelic on `hds-prod-open-pryv-io`. Storage error was caught + logged after the API response had already returned 200, so callers never saw a failure — but per-method counters stayed at baseline.

## Test plan

- [x] `just test storage` — 13/0
- [x] `just test api-server` — 978/0 (new `[BTRK]` regression in `root-seq.test.js` issues a real batched POST and asserts both per-method counters move equally)
- [x] `just lint` clean
- [x] CI

## Audit

Verified no other SET-clause builder in the PG engine has the same shape — all other sites iterate over object keys (which are unique), so distinct keys map to distinct columns. Cross-operator collisions (`$set: { x }, $inc: { x }` on same key) are theoretically vulnerable but no production caller does this.