### PR TITLE
fix(test-helpers): strictNullChecks on parallelWorkerSetup spawn handle

### DIFF
--- a/components/test-helpers/src/parallelWorkerSetup.ts
+++ b/components/test-helpers/src/parallelWorkerSetup.ts
@@ -199,29 +199,33 @@ export async function spawnWorkerRqlited (o: WorkerOverrides): Promise<void> {
     dataDir
   ];
 
-  rqliteChild = spawn(binPath, args, {
+  // Capture the spawned child in a local const so strictNullChecks doesn't
+  // flag every subsequent use — the module-level `rqliteChild` can be reset
+  // to null by the `exit` handler, but `child` is stable within this scope.
+  const child = spawn(binPath, args, {
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: false
   });
+  rqliteChild = child;
 
   // Silently drain stdio so the child doesn't block on a full pipe.
   // Mocha tests don't need rqlited's chatter; the file pidpath gives
   // operators a reproducible log target if they want to attach.
-  rqliteChild.stdout?.on('data', () => {});
-  rqliteChild.stderr?.on('data', () => {});
+  child.stdout?.on('data', () => {});
+  child.stderr?.on('data', () => {});
 
-  rqliteChild.on('error', (err: Error) => {
+  child.on('error', (err: Error) => {
     process.stderr.write(`[parallelWorkerSetup w${o.workerId}] rqlited spawn error: ${err.message}\n`);
   });
 
-  rqliteChild.on('exit', () => {
+  child.on('exit', () => {
     rqliteChild = null;
   });
 
   pidFilePath = path.join(dataDir, 'rqlited.pid');
-  if (rqliteChild.pid != null) {
+  if (child.pid != null) {
     try {
-      fs.writeFileSync(pidFilePath, String(rqliteChild.pid));
+      fs.writeFileSync(pidFilePath, String(child.pid));
     } catch {
       // Pidfile is a courtesy for external cleanup; don't fail the worker over it.
     }


### PR DESCRIPTION
## Summary
- `just typecheck` has been failing on master since `9eb7a8c test(test-helpers): make per-worker parallel harness operational under mocha` — 6× `TS18047 'rqliteChild' is possibly null` in `components/test-helpers/src/parallelWorkerSetup.ts`. The slot is declared `ChildProcess | null` and gets reset by the `'exit'` handler, so strictNullChecks won't trust the just-assigned value at subsequent uses.
- Fix: capture the spawned handle in a local `const child` immediately after `spawn(...)`, route subsequent stdio drains / handlers / pidfile write through `child`. The module-level `rqliteChild` stays as the exit-handler-resettable slot so the stop path's `if (rqliteChild == null)` check still works.

No behaviour change — just unblocks the typecheck CI job. Test runs (`test-postgres`) already green on master after `9eb7a8c` cleared the `[1VIT]` retry flake.

## Test plan
- [x] `just typecheck` green locally
- [ ] CI typecheck job green on this branch
- [ ] CI test-postgres job stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)