### PR TITLE
fix(webhooks): cascade webhook deletion on accesses.delete (Plan 72 B)

### DIFF
--- a/CHANGELOG-v2-back.md
+++ b/CHANGELOG-v2-back.md
@@ -1,5 +1,53 @@
 # Changelog - Internal (no API impact)
 
+## fix(webhooks): cascade webhook deletion on accesses.delete (Plan 72 B)
+
+`accesses.delete` did not remove webhooks attached to the deleted
+access (or its descendant shared accesses for an app-access
+deletion). Webhook rows survived with a dangling `accessId` and kept
+firing notifications until manually cleaned. The data exposure is
+bounded by the signal-only design (the receiver's GET back authenticates
+with the now-deleted access and gets 401), but the outbound channel
+itself was not torn down.
+
+Fix is three small additions:
+
+1. `Repository.deleteByAccess(user, accessId)` in
+   `components/business/src/webhooks/repository.ts` mirrors the existing
+   `deleteOne` / `deleteForUser` shape.
+2. `deleteAccesses` middleware in
+   `components/api-server/src/methods/accesses.ts` walks the same
+   `idsToDelete` list (app access + descendants) and calls
+   `webhooksRepository.deleteByAccess` for each — **before** the access
+   row is deleted, so a partial failure leaves a retryable state.
+3. `Webhook.send()` fire-time access-validity check: on cache miss for
+   the parent access, the repository's new `accessExists(user, accessId)`
+   is consulted and the webhook self-deactivates (`state = 'inactive'`)
+   when the access is missing or tombstoned. Self-heals orphan webhooks
+   from before this fix shipped, and any future code path that creates a
+   dangling webhook.
+
+`WebhooksRepository` constructor gained an optional third parameter
+`accessesStorage`; existing two-arg callers still work (defensive
+default `accessExists` returns true, so no-op for legacy wiring). Three
+known instantiation sites updated: `api-server/src/methods/webhooks.ts`,
+`api-server/src/methods/accesses.ts` (new), and
+`webhooks/src/service.ts` (the dispatcher that actually fires webhooks
+in-process per Plan 14).
+
+Tests:
+
+- `[WCAD]` 3 tests in `components/api-server/test/acceptance/accesses.test.js`
+  cover the cascade (own webhook, descendant webhook, unrelated webhook
+  untouched).
+- `[WCAD-FIRE]` 3 tests in
+  `components/business/test/acceptance/webhooks/Webhook.test.js` cover
+  the fire-time check (missing access, tombstoned access, live access).
+
+Closes the bug chips on `hipaa-security.164.308(a)(3)(ii)(C)`,
+`iso-27001.A.5.16`, `iso-27001.A.5.18` in `compliance-matrix/`.
+GitHub: pryv/open-pryv.io#82.
+
 ## feat(auth.delete): operator setting `audit.onUserDelete` (Plan 72 A.2)
 
 Layered on top of A.1 (which made the erasure engine-consistent), A.2 surfaces the policy choice operators need for retention regimes that conflict with the GDPR Art.17 default:

--- a/components/api-server/src/methods/accesses.ts
+++ b/components/api-server/src/methods/accesses.ts
@@ -34,6 +34,7 @@ const { parseAccessRef, serializeAccessRef, composeWireAccess } = require('busin
 const AccessLogic = require('business/src/accesses/AccessLogic.ts').default;
 const cmc = require('cmc');
 const { getLogger } = require('@pryv/boiler');
+const WebhooksRepository = require('business').webhooks.Repository;
 
 type Permission = {
   streamId: string;
@@ -52,6 +53,7 @@ export default async function produceAccessesApiMethods (api: any) {
   const dbFindOptions = { projection: { calls: 0, deleted: 0 } };
   const mall = await getMall();
   const storageLayer = await getStorageLayer();
+  const webhooksRepository = new WebhooksRepository(storageLayer.webhooks, storageLayer.events, storageLayer.accesses);
 
   // RETRIEVAL
 
@@ -768,6 +770,15 @@ export default async function produceAccessesApiMethods (api: any) {
       if (accessToDelete != null) {
         cache.unsetAccessLogic(context.user.id, accessToDelete);
       }
+    }
+    // Plan 72 Phase B: cascade webhook deletion BEFORE access deletion.
+    // On partial failure, the access still exists so a retry re-runs the cascade.
+    try {
+      for (const idToDelete of idsToDelete) {
+        await webhooksRepository.deleteByAccess(context.user, idToDelete.id);
+      }
+    } catch (err) {
+      return next(errors.unexpectedError(err));
     }
     try {
       await fromCallback((cb: any) => {

--- a/components/api-server/src/methods/webhooks.ts
+++ b/components/api-server/src/methods/webhooks.ts
@@ -37,7 +37,7 @@ export default async function produceWebhooksApiMethods (api: any) {
   const storageLayer = await getStorageLayer();
   const logger = getLogger('methods:webhooks');
 
-  const webhooksRepository = new WebhooksRepository(storageLayer.webhooks, storageLayer.events);
+  const webhooksRepository = new WebhooksRepository(storageLayer.webhooks, storageLayer.events, storageLayer.accesses);
 
   // RETRIEVAL
 

--- a/components/api-server/test/acceptance/accesses.test.js
+++ b/components/api-server/test/acceptance/accesses.test.js
@@ -313,6 +313,88 @@ describe('[AC01] accesses', () => {
     });
   });
 
+  describe('[WCAD] webhook cascade on access delete', () => {
+    let username, streamId, appAccess, sharedAccess, sharedSiblingAccess;
+    let appWebhook, sharedWebhook, siblingWebhook;
+    let mongoFixtures;
+    let webhooksStorage;
+
+    before(async () => {
+      webhooksStorage = helpers.dependencies.storage.user.webhooks;
+    });
+
+    before(async () => {
+      username = cuid();
+      streamId = charlatan.Lorem.word();
+      mongoFixtures = getNewFixture();
+      const user = await mongoFixtures.user(username);
+      await user.stream({ id: streamId }, () => {});
+
+      appAccess = (await user.access({
+        type: 'app',
+        name: charlatan.Lorem.word() + '-app',
+        permissions: [{ streamId, level: 'read' }]
+      })).attrs;
+
+      sharedAccess = (await user.access({
+        type: 'shared',
+        name: charlatan.Lorem.word() + '-shared',
+        permissions: [{ streamId, level: 'read' }],
+        createdBy: appAccess.id
+      })).attrs;
+
+      // Unrelated shared access — its webhook must survive.
+      sharedSiblingAccess = (await user.access({
+        type: 'shared',
+        name: charlatan.Lorem.word() + '-sibling',
+        permissions: [{ streamId, level: 'read' }]
+      })).attrs;
+
+      appWebhook = (await user.webhook({
+        url: `https://${charlatan.Internet.domainName()}/app-notify`
+      }, appAccess.id)).attrs;
+
+      sharedWebhook = (await user.webhook({
+        url: `https://${charlatan.Internet.domainName()}/shared-notify`
+      }, sharedAccess.id)).attrs;
+
+      siblingWebhook = (await user.webhook({
+        url: `https://${charlatan.Internet.domainName()}/sibling-notify`
+      }, sharedSiblingAccess.id)).attrs;
+    });
+
+    after(async () => {
+      await mongoFixtures.clean();
+    });
+
+    describe('[WCAD-A] when deleting an app access', () => {
+      before(async () => {
+        await coreRequest
+          .del(`/${username}/accesses/${appAccess.id}`)
+          .set('Authorization', appAccess.token);
+      });
+
+      it('[WCAD1] deletes the webhook attached to the deleted access', async () => {
+        const findOneAsync = promisify((u, q, opts, cb) => webhooksStorage.findOne(u, q, opts, cb));
+        const found = await findOneAsync({ id: username }, { id: appWebhook.id }, {});
+        assert.strictEqual(found, null);
+      });
+
+      it('[WCAD2] cascades to webhooks on descendant shared accesses', async () => {
+        const findOneAsync = promisify((u, q, opts, cb) => webhooksStorage.findOne(u, q, opts, cb));
+        const found = await findOneAsync({ id: username }, { id: sharedWebhook.id }, {});
+        assert.strictEqual(found, null);
+      });
+
+      it('[WCAD3] does NOT touch webhooks on unrelated accesses', async () => {
+        const findOneAsync = promisify((u, q, opts, cb) => webhooksStorage.findOne(u, q, opts, cb));
+        const found = await findOneAsync({ id: username }, { id: siblingWebhook.id }, {});
+        assert.ok(found != null);
+        assert.strictEqual(found.id, siblingWebhook.id);
+      });
+    });
+  });
+
   describe('[AC11] access expiry', () => {
     // Uses dynamic fixtures:
     // Set up a few ids that we'll use for testing. NOTE that these ids will

--- a/components/business/src/webhooks/Webhook.ts
+++ b/components/business/src/webhooks/Webhook.ts
@@ -16,6 +16,7 @@ function pick (obj: any, keys: any) {
 const { createId: cuid } = require('@paralleldrive/cuid2');
 const timestamp = require('unix-timestamp');
 const { pubsub } = require('messages');
+const cache = require('cache').default;
 
 class Webhook {
   id;
@@ -105,6 +106,19 @@ class Webhook {
    */
   async send (message: any, isRescheduled?: any) {
     if (this.state === 'inactive') { return; }
+    // Fire-time access-validity check (Plan 72 B.1.c): self-heal orphan webhooks
+    // whose access was revoked, including those created before the cascade fix shipped.
+    if (this.repository != null && typeof this.repository.accessExists === 'function') {
+      const cacheHit = cache.getAccessLogicForId(this.user.id, this.accessId);
+      if (cacheHit == null) {
+        const stillValid = await this.repository.accessExists(this.user, this.accessId);
+        if (!stillValid) {
+          this.state = 'inactive';
+          await makeUpdate(['state'], this);
+          return;
+        }
+      }
+    }
     if (isRescheduled != null && isRescheduled === true) {
       this.timeout = null;
     }

--- a/components/business/src/webhooks/repository.ts
+++ b/components/business/src/webhooks/repository.ts
@@ -15,8 +15,10 @@ const { getUsersRepository } = require('business/src/users/index.ts');
  */
 class Repository {
   storage: any;
-  constructor (webhooksStorage: any) {
+  accessesStorage: any;
+  constructor (webhooksStorage: any, eventsStorage?: any, accessesStorage?: any) {
     this.storage = webhooksStorage;
+    this.accessesStorage = accessesStorage;
   }
 
   /**
@@ -102,6 +104,26 @@ class Repository {
    */
   async deleteForUser (user: any) {
     await fromCallback((cb: any) => this.storage.delete(user, {}, cb));
+  }
+
+  /**
+   * Deletes all webhooks attached to a given access. Used by the
+   * `accesses.delete` cascade (Plan 72 Phase B).
+   */
+  async deleteByAccess (user: any, accessId: any) {
+    await fromCallback((cb: any) => this.storage.delete(user, { accessId }, cb));
+  }
+
+  /**
+   * Returns true iff an active (non-tombstoned) access exists for the
+   * given accessId. Defensive: returns true when no accessesStorage was
+   * wired (older constructor callers) so we never falsely deactivate.
+   */
+  async accessExists (user: any, accessId: any): Promise<boolean> {
+    if (this.accessesStorage == null) return true;
+    const access = await fromCallback((cb: any) =>
+      this.accessesStorage.findOne(user, { id: accessId }, {}, cb));
+    return access != null && access.deleted == null;
   }
 }
 export default Repository;

--- a/components/business/test/acceptance/webhooks/Webhook.test.js
+++ b/components/business/test/acceptance/webhooks/Webhook.test.js
@@ -13,6 +13,7 @@ const awaiting = require('awaiting');
 
 const Webhook = require('../../../src/webhooks/Webhook.ts').default;
 const WebhooksRepository = require('business/src/webhooks/repository.ts').default;
+const { createId: cuid } = require('@paralleldrive/cuid2');
 
 const HttpServer = require('./support/httpServer').default;
 // Plan 61: keep PORT in sync with httpServer.js's worker-relative shift.
@@ -443,6 +444,81 @@ describe('[WHBK] Webhook', () => {
         assert.deepEqual(runs3[2], runs2[1]);
         assert.deepEqual(runs3[0], webhook.lastRun);
       });
+    });
+  });
+
+  describe('[WCAD-FIRE] fire-time access-validity check (Plan 72 B.1.c)', () => {
+    const postPath = '/should-not-fire';
+    const url = 'http://127.0.0.1:' + PORT + postPath;
+    const user = { id: 'wcad-fire-user', username: 'wcad-fire-user' };
+    let mockServer;
+
+    before(async () => {
+      mockServer = new HttpServer(postPath, 200);
+      await mockServer.listen();
+    });
+
+    after(() => {
+      mockServer.close();
+    });
+
+    it('[WCADF1] when access is gone, marks webhook inactive and skips the HTTP call', async () => {
+      const fakeAccessesStorage = {
+        findOne: (_u, _q, _opts, cb) => cb(null, null) // access not found
+      };
+      const repo = new WebhooksRepository(storage, userStorage, fakeAccessesStorage);
+      const webhook = new Webhook({
+        accessId: cuid(),
+        url,
+        webhooksRepository: repo,
+        user
+      });
+      await webhook.save();
+      const before = mockServer.getMessages().length;
+      await webhook.send('should-not-be-sent');
+      assert.strictEqual(webhook.state, 'inactive');
+      assert.strictEqual(mockServer.getMessages().length, before);
+      const stored = await repo.getById(user, webhook.id);
+      assert.strictEqual(stored.state, 'inactive');
+      await repo.deleteOne(user, webhook.id);
+    });
+
+    it('[WCADF2] when access is tombstoned (deleted != null), marks webhook inactive', async () => {
+      const fakeAccessesStorage = {
+        findOne: (_u, q, _opts, cb) => cb(null, { id: q.id, deleted: 1700000000 })
+      };
+      const repo = new WebhooksRepository(storage, userStorage, fakeAccessesStorage);
+      const webhook = new Webhook({
+        accessId: cuid(),
+        url,
+        webhooksRepository: repo,
+        user
+      });
+      await webhook.save();
+      const before = mockServer.getMessages().length;
+      await webhook.send('should-not-be-sent');
+      assert.strictEqual(webhook.state, 'inactive');
+      assert.strictEqual(mockServer.getMessages().length, before);
+      await repo.deleteOne(user, webhook.id);
+    });
+
+    it('[WCADF3] when access is live, fires normally', async () => {
+      const fakeAccessesStorage = {
+        findOne: (_u, q, _opts, cb) => cb(null, { id: q.id, deleted: null })
+      };
+      const repo = new WebhooksRepository(storage, userStorage, fakeAccessesStorage);
+      const webhook = new Webhook({
+        accessId: cuid(),
+        url,
+        webhooksRepository: repo,
+        user
+      });
+      await webhook.save();
+      const before = mockServer.getMessages().length;
+      await webhook.send('should-fire');
+      assert.strictEqual(webhook.state, 'active');
+      assert.strictEqual(mockServer.getMessages().length, before + 1);
+      await repo.deleteOne(user, webhook.id);
     });
   });
 });

--- a/components/webhooks/src/service.ts
+++ b/components/webhooks/src/service.ts
@@ -24,7 +24,7 @@ class WebhooksService {
   settings: any;
   constructor (params: any) {
     this.logger = params.logger;
-    this.repository = new WebhooksRepository(params.storage.webhooks);
+    this.repository = new WebhooksRepository(params.storage.webhooks, params.storage.events, params.storage.accesses);
     this.settings = params.settings;
   }
 


### PR DESCRIPTION
## Summary

`accesses.delete` left webhooks attached to the deleted access (or its descendant shared accesses for an app-access deletion) firing into a now-dangling `accessId`. Data exposure is bounded by the signal-only design (the receiver's GET back returns 401), but the outbound channel itself was not torn down.

Three small additions:

1. `Repository.deleteByAccess(user, accessId)` in `components/business/src/webhooks/repository.ts` mirrors the existing `deleteOne` / `deleteForUser` shape.
2. `deleteAccesses` middleware in `components/api-server/src/methods/accesses.ts` walks the same `idsToDelete` list (app access + descendants from `findRelatedAccesses`) and calls `webhooksRepository.deleteByAccess` for each — **before** the access row is deleted, so a partial failure leaves a retryable state.
3. `Webhook.send()` fire-time access-validity check: on cache miss for the parent access, the repository's new `accessExists(user, accessId)` is consulted and the webhook self-deactivates when the access is missing or tombstoned. Self-heals orphan webhooks from before this fix shipped.

Drive-in (test infrastructure): `business/test/acceptance/webhooks/support/httpServer.js` `listen()` now wraps `express.app.listen()` in a callback Promise so the bind is actually awaited (the prior `await` was a no-op because express returns synchronously).

Discharges 3 bug chips on `hipaa-security.164.308(a)(3)(ii)(C)`, `iso-27001.A.5.16`, `iso-27001.A.5.18` in the compliance-matrix on merge.

## Test plan

- [x] `just typecheck` green
- [x] eslint clean on touched files
- [ ] CI `test-postgres` green (may need rerun if it hits upstream parallel-harness flake)
- New tests: `[WCAD1-3]` cascade (api-server acceptance) + `[WCADF1-3]` fire-time self-heal (business/Webhook.test.js)

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)