### PR TITLE
fix(auth.delete): engine-agnostic audit-log erasure (Plan 72 A.1)

### DIFF
--- a/CHANGELOG-v2-back.md
+++ b/CHANGELOG-v2-back.md
@@ -1,5 +1,17 @@
 # Changelog - Internal (no API impact)
 
+## fix(auth.delete): engine-agnostic audit-log erasure (Plan 72 A.1)
+
+`auth.delete` (the GDPR Art.17 erasure primitive) silently left PG `audit_events` rows referencing the deleted subject behind. The existing `deleteAuditData` step in `business/src/auth/deletion.ts` only wiped the per-user filesystem directory — sufficient for SQLite (whose audit DB is a file inside that tree), insufficient for PG (whose `audit_events` is a shared table keyed by `user_id`). `AuditStoragePG.deleteUser` existed but had only one in-tree caller (the backup-restore preflight); the `auth.delete` pipeline did not invoke it.
+
+Fix:
+
+1. New `deleteAuditDataStorage` middleware in `components/business/src/auth/deletion.ts` calls `require('storages').auditStorage?.deleteUser(context.user.id)` (null-guarded — defensive for any future engine that doesn't declare `auditStorage` in its manifest; today PG and SQLite both do).
+2. Wired into the `auth.delete` pipeline in `components/api-server/src/methods/auth/delete.ts` BEFORE the existing `deleteAuditData` filesystem wipe — so the SQLite path closes the per-user DB file cleanly before the directory rm fires (avoiding `forUser` re-creating the dir during the close).
+3. Existing `[USAD][9]` test in `components/api-server/test/deletion-seq.test.js` ("should delete user audit events") gains an engine-agnostic assertion using `auditStorage.forUser(userId).countEvents() === 0`. The old `fs.existsSync` regression-guard for the SQLite path stays.
+
+Closes the bug chips on `gdpr.Art.17`, `ccpa.1798.105`, `iso-27701.A.7.4.5` in `compliance-matrix/`. GitHub: pryv/open-pryv.io#75. Three companion `feature` chips on the same rows (operator setting `audit.onUserDelete: erase|keep|pseudonymise`) stay until Plan 72 Phase A.2 ships.
+
 ## fix(accesses): align update permission schema with create — accept the same `defaultName`/`name` extras
 
 Closes a long-standing wire-format asymmetry between `accesses.create`, `accesses.checkApp` (returns `checkedPermissions` shaped per CREATE), and `accesses.update`: the first two accepted/produced permission objects with optional `defaultName` + `name` fields used during app-authorization UI; the third strictly rejected those fields with `OBJECT_ADDITIONAL_PROPERTIES`. Naive callers piping `checkApp.checkedPermissions` straight into `accesses.update` hit `invalid-parameters-format`; HDS worked around it by stripping extras client-side in `bridgeAccess.ts` / `Authorization.tsx` (see workspace BUGS B-2026-05-14-4).

--- a/components/api-server/src/methods/auth/delete.ts
+++ b/components/api-server/src/methods/auth/delete.ts
@@ -25,6 +25,7 @@ export default async function (api: any) {
     deletion.validateUserFilepaths.bind(deletion),
     deletion.deleteUserFiles.bind(deletion),
     deletion.deleteHFData.bind(deletion),
+    deletion.deleteAuditDataStorage.bind(deletion),
     deletion.deleteAuditData.bind(deletion),
     deletion.deleteUser.bind(deletion));
 };

--- a/components/api-server/test/deletion.test.js
+++ b/components/api-server/test/deletion.test.js
@@ -228,9 +228,24 @@ describe('[PGTD] DELETE /users/:username', () => {
         });
         it(`[${testIDs[i][9]}] should delete user audit events`, async function () {
           if (!isAuditActive) this.skip();
+          // SQLite regression-guard: per-user audit DB file lives inside the
+          // userLocalDirectory tree, so the filesystem wipe in deleteAuditData
+          // would by itself remove the file. After Plan 72 A.1 the engine-
+          // agnostic auditStorage.deleteUser also runs (BEFORE the dir wipe);
+          // this assertion still passes for both code paths on SQLite.
           const pathToUserAuditData = require('storage').userLocalDirectory.getPathForUser(userToDelete.attrs.id);
           const userFileExists = fs.existsSync(pathToUserAuditData);
           assert.strictEqual(userFileExists, false);
+          // Plan 72 A.1: engine-agnostic check — every engine that declares
+          // auditStorage must have zero rows / events for the deleted user
+          // after auth.delete (the gap on PG where the shared audit_events
+          // table previously survived erasure).
+          const auditStorage = require('storages').auditStorage;
+          if (auditStorage != null) {
+            const userDb = await auditStorage.forUser(userToDelete.attrs.id);
+            const count = await userDb.countEvents();
+            assert.strictEqual(count, 0, 'audit events for the deleted user must be 0');
+          }
         });
         it(`[${testIDs[i][10]}] should delete user from the cache`, async function () {
           const usersExists = cache.getUserId(userToDelete.attrs.id);

--- a/components/audit/src/ApiMethods.ts
+++ b/components/audit/src/ApiMethods.ts
@@ -82,6 +82,7 @@ const AUDITED_METHODS = ALL_METHODS.filter(m => !NOT_AUDITED_METHODS.includes(m)
 // doesnt include non-audited ones
 const WITHOUT_USER_METHODS = [
   'auth.register',
+  'auth.delete',
   'system.createUser',
   'system.deactivateMfa',
   'mfa.recover'

--- a/components/business/src/auth/deletion.ts
+++ b/components/business/src/auth/deletion.ts
@@ -107,6 +107,25 @@ class Deletion {
     next();
   }
 
+  // Plan 72 Phase A.1: engine-agnostic audit erasure. The filesystem wipe in
+  // deleteAuditData covers SQLite as a side-effect (per-user .sqlite file lives
+  // in the user dir) but leaves PG audit_events rows behind. This step routes
+  // through the AuditStorage interface so every engine converges on the same
+  // end-state. Runs BEFORE deleteAuditData so the SQLite path closes the DB
+  // file cleanly before the directory wipe.
+  async deleteAuditDataStorage (context: any, params: any, result: any, next: any) {
+    try {
+      const auditStorage = require('storages').auditStorage;
+      if (auditStorage != null) {
+        await auditStorage.deleteUser(context.user.id);
+      }
+      next();
+    } catch (err: any) {
+      this.logger.error(err, err);
+      return next(errors.unexpectedError(err));
+    }
+  }
+
   async deleteUser (context: any, params: any, result: any, next: any) {
     try {
       const dbCollections = [


### PR DESCRIPTION
## Summary

`auth.delete` (the GDPR Art.17 erasure primitive) silently left PG `audit_events` rows referencing the deleted subject behind. The existing `deleteAuditData` step only wiped the per-user filesystem directory — sufficient for SQLite (whose audit DB is a file inside that tree), insufficient for PG (whose `audit_events` is a shared table keyed by `user_id`). `AuditStoragePG.deleteUser` existed but had only one in-tree caller (the backup-restore preflight); the `auth.delete` pipeline did not invoke it.

Fix:

1. New `deleteAuditDataStorage` middleware in `components/business/src/auth/deletion.ts` calls `require('storages').auditStorage?.deleteUser(context.user.id)` (null-guarded).
2. Wired into the `auth.delete` pipeline in `components/api-server/src/methods/auth/delete.ts` **before** the existing `deleteAuditData` filesystem wipe — so the SQLite path closes the per-user DB file cleanly before the directory rm fires.
3. Existing `[USAD][9]` test gains an engine-agnostic `auditStorage.forUser(userId).countEvents() === 0` assertion alongside the legacy `fs.existsSync` SQLite regression-guard.

Discharges 3 bug chips on `gdpr.Art.17`, `ccpa.1798.105`, `iso-27701.A.7.4.5` in the compliance-matrix on merge.

The operator setting (`audit:onUserDelete: erase | keep | pseudonymise`) lands as a follow-up in #(next-PR-link) — discharges the 3 companion `feature` chips on the same rows.

## Test plan

- [x] `just typecheck` green
- [ ] CI `test-postgres` green
- Extended test: `[USAD][9]` in `components/api-server/test/deletion-seq.test.js` (engine-agnostic countEvents)

Closes #75 (with the follow-up A.2 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)