### PR TITLE
fix(justfile): clean-test-data falls back to system dropdb/createdb/mongosh

### DIFF
--- a/CHANGELOG-v2-back.md
+++ b/CHANGELOG-v2-back.md
@@ -1,5 +1,13 @@
 # Changelog - Internal (no API impact)
 
+## fix(justfile): `clean-test-data` falls back to system `dropdb`/`createdb`/`mongosh` when local `var-pryv/<engine>-bin/` is absent
+
+The `clean-test-data` + `clean-test-data-parallel` recipes hardcoded `./var-pryv/postgresql-bin/bin/dropdb` etc. — if that local install was absent (e.g. on a Darwin dev box where the operator uses Homebrew / Postgres.app instead of running `storages/engines/postgresql/scripts/setup`), the recipes swallowed the binary-not-found failure as `... not reachable (skipping ...)` and silently left the prior run's PG/Mongo state in place. Tests then tripped on stale residue (e.g. webhook-lifecycle `[WH01]` flakes documented in workspace memory).
+
+Both recipes now resolve `DROPDB`/`CREATEDB`/`MONGOSH` by preferring the local Plan-41 install if present, otherwise falling back to whatever is on PATH (`command -v dropdb` etc.). The skip-message path is preserved but now distinguishes "binary not found" from "server not reachable" so operators see the real cause.
+
+Verified on Darwin: local bin present → unchanged behaviour; local bin hidden + system bin on PATH → fallback invoked correctly; both missing → clear "not found" message instead of misleading "not reachable".
+
 ## fix(cmc): auto-provision per-app appScope roots on `accesses.create` / `accesses.update`
 
 The 5 reserved parents under `:_cmc:*` are pre-provisioned at user creation by [`components/cmc/src/provisioning.ts`](components/cmc/src/provisioning.ts). Per-app sub-trees under `:_cmc:apps:<app-code>` were historically created on-demand at CMC-acceptance time (`provisioning.ts:21-26`) — but the OAuth-grant flow used by `doctor-dashboard` (via `app-web-auth-3`) never reaches an acceptance event before the first invite, leaving the per-app *root* `:_cmc:apps:<app-code>` missing. Downstream `streams.create` for a child of the leaf then failed with `unknown-referenced-resource` ("Unknown referenced unknown Stream"). Bridge-onboarded doctors escape this because their onboarding flow uses a personal token to pre-create the stream — OAuth-onboarded ones cannot.

--- a/justfile
+++ b/justfile
@@ -175,6 +175,28 @@ test-data command version:
 
 # Reset test state: SQLite DBs, user dirs, and MongoDB user collections (keeps MongoDB running)
 clean-test-data:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    # Resolve PG client binaries: prefer the local Plan-41 install at
+    # ./var-pryv/postgresql-bin/bin/ (Linux dev + Darwin dev when the
+    # PG setup script ran), fall back to system `dropdb`/`createdb`
+    # found on PATH (Darwin operators using Homebrew / Postgres.app /
+    # the system PG that ships with macOS). Same for `mongosh`. If
+    # neither resolves, the recipe still reports the skip — but at
+    # least the local-bin-missing case no longer hides the issue from
+    # operators who DO have the system tools installed.
+    if [ -x ./var-pryv/postgresql-bin/bin/dropdb ]; then
+      DROPDB=./var-pryv/postgresql-bin/bin/dropdb
+      CREATEDB=./var-pryv/postgresql-bin/bin/createdb
+    else
+      DROPDB=$(command -v dropdb || true)
+      CREATEDB=$(command -v createdb || true)
+    fi
+    if [ -x ./var-pryv/mongodb-bin/bin/mongosh ]; then
+      MONGOSH=./var-pryv/mongodb-bin/bin/mongosh
+    else
+      MONGOSH=$(command -v mongosh || true)
+    fi
     # SQLite user index + legacy pre-Plan-25 platform-wide.db (retained for safety)
     rm -f ./var-pryv/users/user-index.db ./var-pryv/users/user-index.db-wal ./var-pryv/users/user-index.db-shm
     rm -f ./var-pryv/users/platform-wide.db ./var-pryv/users/platform-wide.db-wal ./var-pryv/users/platform-wide.db-shm
@@ -191,16 +213,24 @@ clean-test-data:
     # cleans and cause "user exists in repo but missing in index"
     # symptoms on the next prepare (e.g. lib-js's [UEMX]). The mongo
     # server is kept running.
-    ./var-pryv/mongodb-bin/bin/mongosh --quiet pryv-node-test --eval 'db.dropDatabase()' > /dev/null 2>&1 || echo "MongoDB not reachable (skipping mongo test reset)"
-    ./var-pryv/mongodb-bin/bin/mongosh --quiet pryv-node --eval 'db.dropDatabase()' > /dev/null 2>&1 || echo "MongoDB not reachable (skipping mongo dev reset)"
+    if [ -n "$MONGOSH" ]; then
+      "$MONGOSH" --quiet pryv-node-test --eval 'db.dropDatabase()' > /dev/null 2>&1 || echo "MongoDB not reachable (skipping mongo test reset)"
+      "$MONGOSH" --quiet pryv-node --eval 'db.dropDatabase()' > /dev/null 2>&1 || echo "MongoDB not reachable (skipping mongo dev reset)"
+    else
+      echo "mongosh not found (skipping mongo test reset + mongo dev reset)"
+    fi
     # PostgreSQL databases — same logic as Mongo above: drop+recreate
     # both pryv-node-test (test harness) AND pryv-node (local dev /
     # bin/master.js). Tests re-run migrations on next startup; the
     # local server runs them on next master boot.
-    (./var-pryv/postgresql-bin/bin/dropdb -h 127.0.0.1 -p 5432 -U pryv --if-exists pryv-node-test 2>/dev/null && \
-        ./var-pryv/postgresql-bin/bin/createdb -h 127.0.0.1 -p 5432 -U pryv pryv-node-test 2>/dev/null) || echo "PostgreSQL not reachable (skipping pg test reset)"
-    (./var-pryv/postgresql-bin/bin/dropdb -h 127.0.0.1 -p 5432 -U pryv --if-exists pryv-node 2>/dev/null && \
-        ./var-pryv/postgresql-bin/bin/createdb -h 127.0.0.1 -p 5432 -U pryv pryv-node 2>/dev/null) || echo "PostgreSQL not reachable (skipping pg dev reset)"
+    if [ -n "$DROPDB" ] && [ -n "$CREATEDB" ]; then
+      ("$DROPDB" -h 127.0.0.1 -p 5432 -U pryv --if-exists pryv-node-test 2>/dev/null && \
+          "$CREATEDB" -h 127.0.0.1 -p 5432 -U pryv pryv-node-test 2>/dev/null) || echo "PostgreSQL not reachable (skipping pg test reset)"
+      ("$DROPDB" -h 127.0.0.1 -p 5432 -U pryv --if-exists pryv-node 2>/dev/null && \
+          "$CREATEDB" -h 127.0.0.1 -p 5432 -U pryv pryv-node 2>/dev/null) || echo "PostgreSQL not reachable (skipping pg dev reset)"
+    else
+      echo "dropdb/createdb not found (skipping pg test reset + pg dev reset)"
+    fi
     # rqlite PlatformDB key-value table (Plan 25: rqlite is the only
     # platform engine). Wipes both the test harness state AND the
     # local-dev email/platform-unique index — paired with the PG
@@ -209,7 +239,7 @@ clean-test-data:
     curl -s -X POST -H 'Content-Type: application/json' 'http://localhost:4001/db/execute' -d '[["DELETE FROM keyValue"]]' > /dev/null 2>&1 || echo "rqlite not reachable (skipping rqlite reset)"
     # Stale customAuthStepFn from a prior aborted permissions-seq test (the [P4OM] invalid-fixture test crashes the api-server bin and leaves the file behind, polluting subsequent matrix runs with [api-server fatal] Not a function (string)). Safe to delete unconditionally — committed file is .gitkeep.
     rm -f ./custom-extensions/customAuthStepFn.js
-    @echo "Test data cleaned: SQLite + per-user dirs + attachments/previews + Mongo (pryv-node-test + pryv-node) + PG (pryv-node-test + pryv-node) + rqlite keyValue + custom-extensions stale fixture"
+    echo "Test data cleaned: SQLite + per-user dirs + attachments/previews + Mongo (pryv-node-test + pryv-node) + PG (pryv-node-test + pryv-node) + rqlite keyValue + custom-extensions stale fixture"
 
 # Reset per-worker test state for parallel mode (Plan 61 Stage 3).
 # Wipes worker-private PG DBs (pryv-node-test-w0..N), per-worker user
@@ -242,6 +272,21 @@ clean-test-data-parallel WORKERS='':
         WORKERS=$(( N > 2 ? N - 1 : 2 ))
       fi
     fi
+    # Resolve PG + mongosh binaries (mirror of `clean-test-data`): prefer
+    # the local Plan-41 install at ./var-pryv/<engine>-bin/bin/, fall
+    # back to system tooling on PATH (Darwin Homebrew / Postgres.app).
+    if [ -x ./var-pryv/postgresql-bin/bin/dropdb ]; then
+      DROPDB=./var-pryv/postgresql-bin/bin/dropdb
+      CREATEDB=./var-pryv/postgresql-bin/bin/createdb
+    else
+      DROPDB=$(command -v dropdb || true)
+      CREATEDB=$(command -v createdb || true)
+    fi
+    if [ -x ./var-pryv/mongodb-bin/bin/mongosh ]; then
+      MONGOSH=./var-pryv/mongodb-bin/bin/mongosh
+    else
+      MONGOSH=$(command -v mongosh || true)
+    fi
     # Plan 61 overhead-pass: parallelize the per-worker cleanup. Each
     # iteration is independent (different DB name + dir paths), so they
     # can fan out via background jobs + `wait`. Wall time on the dev box
@@ -260,9 +305,13 @@ clean-test-data-parallel WORKERS='':
         kill -KILL "$(cat "$PID")" 2>/dev/null || true
         rm -f "$PID"
       fi
-      ./var-pryv/postgresql-bin/bin/dropdb -h 127.0.0.1 -p 5432 -U pryv --if-exists "$DB" 2>/dev/null || true
-      ./var-pryv/postgresql-bin/bin/createdb -h 127.0.0.1 -p 5432 -U pryv "$DB" 2>/dev/null || true
-      ./var-pryv/mongodb-bin/bin/mongosh --quiet "$DB" --eval 'db.dropDatabase()' >/dev/null 2>&1 || true
+      if [ -n "$DROPDB" ] && [ -n "$CREATEDB" ]; then
+        "$DROPDB" -h 127.0.0.1 -p 5432 -U pryv --if-exists "$DB" 2>/dev/null || true
+        "$CREATEDB" -h 127.0.0.1 -p 5432 -U pryv "$DB" 2>/dev/null || true
+      fi
+      if [ -n "$MONGOSH" ]; then
+        "$MONGOSH" --quiet "$DB" --eval 'db.dropDatabase()' >/dev/null 2>&1 || true
+      fi
       rm -rf "$USR" "$PRV" "$RQD" "$CEX"
     }
     for i in $(seq 0 $(( WORKERS - 1 ))); do


### PR DESCRIPTION
## Summary

- `clean-test-data` and `clean-test-data-parallel` hardcoded `./var-pryv/<engine>-bin/bin/...`; absent on Darwin operators using Homebrew / Postgres.app → silent skip → stale state across reruns → flakes like `[WH01]`.
- Both recipes now resolve `DROPDB`/`CREATEDB`/`MONGOSH` with a local-first → system-PATH fallback (`command -v`).
- Skip messages distinguish "binary not found" from "server not reachable" so the real cause is visible.

Closes [B-2026-05-26-3](https://github.com/pryv/macroPryv/blob/main/_plans/BUGS.md#b-2026-05-26-3---macropryv-_localscriptsclean-test-datash-pg-reset-silently-skipped-on-darwin) in the workspace BUGS log.

## Test plan

- [x] Local bin present (Darwin, this dev box) → unchanged behaviour, PG reset succeeds, Mongo skip (mongod not running)
- [x] Local bin hidden + fake `dropdb`/`createdb` on PATH → fallback invokes system tooling with correct args
- [x] Both missing → clear "dropdb/createdb not found" message instead of misleading "PostgreSQL not reachable"
- [x] `just --list` parses cleanly
- [x] `just clean-test-data-parallel 2` smoke-test passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)