### PR TITLE
fix(cmc): remove duplicate ProvisionDeps type alias in hooks.ts

### DIFF
--- a/components/cmc/src/hooks.ts
+++ b/components/cmc/src/hooks.ts
@@ -212,11 +212,6 @@ function createStreamDeleteReservedRootHook (deps: Deps): Middleware {
  * Failure is non-fatal (logged) — the downstream call will surface a
  * clearer "parent not found" error if provisioning truly didn't take.
  */
-type ProvisionDeps = {
-  mall: { streams: { create: (userId: string, params: any) => Promise<any> } };
-  logger?: { debug: Function; warn: Function };
-};
-
 function createEnsureReservedParentsHook (deps: ProvisionDeps): Middleware {
   return async function cmcEnsureReservedParents (context, _params, _result, next) {
     const userId: string | undefined = context?.user?.id;


### PR DESCRIPTION
The type was declared twice in `components/cmc/src/hooks.ts` (lines 215 and 509); TS2300 broke `just typecheck` on master.

The two declarations were near-equivalent but the later one used proper optional-method signatures for the logger fields, matching how both hook bodies already access them via optional chaining (`deps.logger?.warn?.(...)`). Removed the earlier looser declaration; all three callers in api-server pass real loggers from `getLogger(...)` so the consolidated shape is safe.

Verification:
- `just typecheck`: 0 errors
- `just test cmc`: 396 passing, 0 failing

Note: `test-postgres` CI job will still be red on this PR — that's a separate regression (ECONNRESET on pg-pool bootstrap, introduced 2026-05-21 by commit 1636063) addressed in a sibling PR.