### PR TITLE
fix(storage/pg): bounded retry on bootstrap connection

### DIFF
--- a/storages/engines/postgresql/src/DatabasePG.ts
+++ b/storages/engines/postgresql/src/DatabasePG.ts
@@ -81,13 +81,26 @@ class DatabasePG {
 
   /**
    * Wait until PG is up. For use at startup.
+   *
+   * Defends against transient TCP resets during bootstrap (observed in
+   * GHA test runs against a dockerized postgres service container,
+   * where the first pool.connect() occasionally fails with ECONNRESET
+   * while load ramps up). 1-second backoff between attempts; throws
+   * after `maxRetries` consecutive failures so genuine config errors
+   * (wrong host/port/auth) surface within a bounded window.
    */
-  async waitForConnection (): Promise<void> {
+  async waitForConnection (maxRetries: number = 30): Promise<void> {
+    let attempts = 0;
     while (!this.connected) {
       try {
         await this.ensureConnect();
       } catch (err) {
-        this.logger.warn(`Cannot connect to PostgreSQL at ${this.poolConfig.host}:${this.poolConfig.port}, retrying in a sec`);
+        attempts++;
+        if (attempts >= maxRetries) {
+          this.logger.error(`Cannot connect to PostgreSQL at ${this.poolConfig.host}:${this.poolConfig.port} after ${attempts} attempts; giving up.`);
+          throw err;
+        }
+        this.logger.warn(`Cannot connect to PostgreSQL at ${this.poolConfig.host}:${this.poolConfig.port} (attempt ${attempts}/${maxRetries}), retrying in a sec`);
         await setTimeout(1000);
       }
     }

--- a/storages/engines/postgresql/src/userAccountStorage.ts
+++ b/storages/engines/postgresql/src/userAccountStorage.ts
@@ -17,7 +17,10 @@ let db: any;
 const userAccountStorage = _internals.createUserAccountStorage({
   async init (): Promise<void> {
     db = _internals.databasePG;
-    await db.ensureConnect();
+    // waitForConnection (bounded retry) instead of single-shot
+    // ensureConnect — defends test/production bootstrap against
+    // transient TCP resets while the PG service ramps up.
+    await db.waitForConnection();
   },
 
   async getPasswordHash (userId: string): Promise<string | undefined> {


### PR DESCRIPTION
`DatabasePG.waitForConnection` takes `maxRetries` (default 30, 1s backoff per attempt = ~30s window), then throws — so genuine config errors still surface within bounded time. `userAccountStorage.init` switches from single-shot `ensureConnect` to `waitForConnection`.

## Why

CI's `test-postgres` job has been 100% red on master since 2026-05-21 with a deterministic `Error: read ECONNRESET` at `pg-pool`'s first connect, on the very first api-server test's `before all` hook. Stack:

```
"before all" hook in "{root}":
   Error: read ECONNRESET
    at node_modules/pg-pool/index.js:45:11
    at async DatabasePG._doConnect (storages/engines/postgresql/src/DatabasePG.ts:70:20)
    at async DatabasePG.ensureConnect (storages/engines/postgresql/src/DatabasePG.ts:53:7)
    at async Object.init (storages/engines/postgresql/src/userAccountStorage.ts:20:5)
    at async Module.init (storages/index.ts:143:3)
    ...
    at async Context.<anonymous> (components/api-server/test/helpers/global.test.js:15)
```

Direct PG client failure, not supertest/HTTP. Single-shot `_doConnect` has no retry; under GHA's load profile (dockerized PG service + many concurrent backend forks during bootstrap — PID-jump signal of ~615 PG-touching processes in 5s during the failure window) the first `pool.connect()` occasionally trips a TCP reset.

The pre-existing `waitForConnection` already wraps `ensureConnect` in retry-on-failure (1s backoff). This PR bounds it (`maxRetries: number = 30`, default ~30s window) and switches bootstrap callers to use it.

## Verification

- `just typecheck`: 0 errors
- `just test api-server` (CI env shape, post `just clean-test-data`): 1073/0 (Darwin)
- `just test storages`: 48/0 (Darwin)
- `just test api-server` on mbp2 (Linux x86_64 CI-shape parity): 1071/2 — both failures are the documented pre-existing flake class (`[EVST][SE1K]` chunk-stream timeout + `[WH01][XMB7]` 403/200), not new regressions