### PR TITLE
ci: target real test DB in postgres healthcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,16 @@ jobs:
           POSTGRES_DB: pryv-node-test
         ports:
           - 5432:5432
+        # pg_isready WITHOUT -d defaults to db=$USER (pryv), which is not
+        # created — every healthcheck triggered a backend fork that hit
+        # `FATAL: database "pryv" does not exist` (visible 5s-interval
+        # spam in PG service logs). Hypothesis: that churn (~615 PG-touching
+        # processes / 5s window during test startup) contributed to the
+        # first pool.connect() ECONNRESET that broke test-postgres since
+        # 2026-05-21. Probing the real test DB stops the spam and avoids
+        # backend churn during the bootstrap window.
         options: >-
-          --health-cmd "pg_isready -U pryv"
+          --health-cmd "pg_isready -U pryv -d pryv-node-test"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
Single-line workflow change: add `-d pryv-node-test` to the postgres service container's `pg_isready` healthcheck.

**Why:** without `-d`, `pg_isready -U pryv` defaulted to db=`pryv`, which is never created (workflow sets `POSTGRES_DB: pryv-node-test`). Every 5s healthcheck triggered a backend fork that immediately hit `FATAL: database "pryv" does not exist` — a relentless spam in the PG service container's log (visible in the failed-CI artifacts).

**Effect of this PR:** silences that healthcheck-side log spam. Strictly additive — no app/test code change.

**What this does NOT fix:** the underlying `test-postgres` ECONNRESET on the first api-server test's `pool.connect()`. That regression (master CI 100% red since 2026-05-21) has a deeper root cause not addressed here. Initial hypothesis was that healthcheck-induced backend churn pressured PG into resetting connections — confirmed wrong by this PR's CI (the spam is gone but the ECONNRESET still happens, deterministically, ~2s into the api-server bootstrap). Two stacked client-side retry experiments (`waitForConnection` with and without pool-recreate) both hung the entire test process silently for 18 min, well past GHA's 20-min timeout — they made things strictly worse and were reverted. Landing this healthcheck fix standalone so the CI log noise is reduced before the next round of investigation.

**Follow-up:** ECONNRESET root-cause investigation needs an instrumented repro (mbp2 + dockerized PG + `DEBUG=pg:*`) rather than the GHA-trial-and-error loop. Will be tracked in a separate plan.