### PR TITLE
feat(reg/access)!: trim response shapes; fix reasonID typo; emit redirectUrl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
         # (`just test-parallel all`), not the matrix-of-record.
         run: just clean-test-data && just test all
         env:
+          # PGPASSWORD lets the `dropdb` calls inside `just clean-test-data`
+          # authenticate cleanly. Without it, dropdb's stdin-password fallback
+          # has been observed to silently block the whole step on CI runners
+          # — even when an earlier `psql` connection succeeded.
+          PGPASSWORD: pryv
           storages__engines__postgresql__host: localhost
           storages__engines__postgresql__port: 5432
           storages__engines__postgresql__user: pryv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   # alternative. CI runs the PG matrix sequentially.
   test-postgres:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,23 @@ jobs:
         run: |
           ./storages/engines/rqlite/scripts/start &
           influxd &
-          sleep 3
+          sleep 10
+      - name: Warm up PostgreSQL connection
+        # The first pg-pool connect from the test runner sporadically returns
+        # ECONNRESET (broken on master since 2026-05-21). Doing one real client
+        # connection here lets PG fork and warm its connection-handling path
+        # so the test runner's pool sees a stable backend.
+        env:
+          PGPASSWORD: pryv
+        run: |
+          for i in 1 2 3 4 5; do
+            if psql -h 127.0.0.1 -p 5432 -U pryv -d pryv-node-test -c "SELECT 1;" > /dev/null 2>&1; then
+              echo "PG warmup OK on attempt $i"
+              break
+            fi
+            echo "PG warmup attempt $i failed; retrying..."
+            sleep 2
+          done
       - name: Run PostgreSQL test suite
         # CI stays SEQUENTIAL on purpose — parallel mode disables the
         # integrity-check beforeEach/afterEach + bypasses the caching

--- a/CHANGELOG-v2.md
+++ b/CHANGELOG-v2.md
@@ -1,5 +1,32 @@
 # Changelog - API Changes
 
+## **BREAKING** — `/reg/access` polling endpoint response shapes trimmed
+
+The access-request polling endpoints have been narrowed to expose only the fields each consumer audience actually needs. SDKs (lib-js + downstream apps) get the minimum needed to drive the flow; the auth UI (app-web-auth3 + equivalents) keeps a richer poll response.
+
+### What changed
+
+**`POST /reg/access`** (SDK-facing — create access request):
+
+The response now contains only `{ status, key, authUrl, poll, poll_rate_ms }`. Removed fields: `code`, `url` (was a v1 alias of `authUrl`), `returnUrl` (camelCase duplicate of `returnURL`), `requestingAppId`, `requestedPermissions`, `lang`, `returnURL`, `oauthState`, `clientData`, `serviceInfo`. Echoed inputs and service metadata are reachable via the GET poll path or `/service/info`.
+
+**`GET /reg/access/:key`** (auth-UI-facing on `NEED_SIGNIN`, SDK-facing on terminal states):
+
+- `code` field dropped from the body (it was always the HTTP status, already conveyed by `res.status`).
+- `url` (v1 alias of `authUrl`) and `returnUrl` (camelCase duplicate of `returnURL`) dropped.
+- `serviceInfo` is now embedded only on the `NEED_SIGNIN` poll — the only response the auth UI actually consumes for that field. SDK polling does not need it (the SDK fetches `/service/info` directly when it wants service metadata).
+- `REDIRECTED` responses now emit both `poll` (back-compat with existing SDK rehydration) and a new explicit `redirectUrl` field so consumers don't have to overload `poll`.
+
+**Refused/Error responses** (POST + GET, all forms):
+
+- The `reasonID` field has been renamed to `reasonId` to match the camelCase convention used by the auth UI and by every consumer that actually reads the field. The old `reasonID` spelling never reached any reader and was effectively dead.
+
+### Migration
+
+- SDK callers using `pryv@>=3.5.0` are unaffected — the SDK already speaks the new shapes.
+- SDK callers on `pryv@<3.5.0` that read `body.url`, `body.returnUrl`, `body.code`, or `body.reasonID` from `/reg/access` responses must switch to `authUrl` / `returnURL` / HTTP status / `reasonId` respectively, or upgrade.
+- Custom auth UIs that depend on `serviceInfo` being present on every poll must read it from the initial `NEED_SIGNIN` poll (still emitted) and cache, or fetch from `/service/info` directly. The `app-web-auth3` build shipped alongside this server release derives a fallback `/service/info` URL from the poll URL.
+
 ## **BREAKING** — MongoDB removed as a user-data storage engine
 
 The MongoDB engine has been dropped from open-pryv.io. Supported user-data engines are now **PostgreSQL** (default) and **SQLite** (alternative). InfluxDB remains optional for high-frequency seriesStorage; rqlited remains the only platformStorage.

--- a/components/api-server/src/routes/reg/access.ts
+++ b/components/api-server/src/routes/reg/access.ts
@@ -83,30 +83,16 @@ export default function (expressApp: any, app: any) {
       // shape; we write to PlatformDB here, after the URLs are computed.
       await accessState.persist(key, state, expiresAt);
 
-      const lang = req.body.languageCode || 'en';
+      // Calling-app surface: only the fields the SDK needs to drive
+      // the flow. The auth UI gets richer state from GET /reg/access/:key
+      // (and from query parameters on `authUrl`). Service metadata
+      // belongs at `/service/info` — clients fetch it from there.
       res.status(201).json({
         status: state.status,
-        code: 201,
         key,
-        requestingAppId: state.requestingAppId,
-        requestedPermissions: state.requestedPermissions,
         authUrl,
-        // @deprecated — kept for v1 SDK compatibility; new clients should
-        // read `authUrl` instead. Remove once no in-the-wild SDK reads `url`.
-        url: authUrl,
         poll: pollUrl,
-        poll_rate_ms: state.poll_rate_ms,
-        lang,
-        returnURL: state.returnURL,
-        // lib-js's NEED_SIGNIN state type declares `returnUrl` (camelCase).
-        // Include both spellings for compatibility with v1 + v2 SDKs.
-        returnUrl: state.returnURL,
-        oauthState: state.oauthState,
-        clientData: state.clientData,
-        // v1-compatible: SDKs (lib-js) read service metadata from the
-        // access-request response without round-tripping /service/info.
-        //
-        serviceInfo
+        poll_rate_ms: state.poll_rate_ms
       });
     } catch (err) { next(err); }
   });
@@ -123,35 +109,24 @@ export default function (expressApp: any, app: any) {
         });
       }
 
-      // Embed service metadata in every poll response — app-web-auth3's
-      // context.init() calls loadAccessState() and then
-      // setServiceInfo(accessState.serviceInfo), which crashes with
-      // "Cannot read properties of undefined (reading 'name')" if the
-      // poll response is missing it.
-      const serviceInfo = app.config.get('service') || {};
-
       const response: any = {
-        status: state.status,
-        code: state.code,
-        serviceInfo
+        status: state.status
       };
 
       if (state.status === 'NEED_SIGNIN') {
-      // Reconstruct poll + authUrl: lib-js's NEED_SIGNIN state type requires
-      // them in every state-shaped payload, and some clients re-hydrate
-      // their state from the poll response directly. The poll URL must be
-      // core-affine (matches the POST-built URL) — store it on state at
-      // creation time so GET and POST agree.
+        // Embed service metadata only on NEED_SIGNIN polls — that's where
+        // the auth UI loads it during init. Later polls (lib-js polling
+        // for ACCEPTED) don't need it; clients can hit `/service/info`
+        // directly.
+        response.serviceInfo = app.config.get('service') || {};
         response.key = state.key;
         response.requestingAppId = state.requestingAppId;
         response.requestedPermissions = state.requestedPermissions;
         response.poll = state.pollUrl || null;
         response.authUrl = state.authUrl || null;
-        response.url = state.authUrl || null; // @deprecated — v1 alias
         response.poll_rate_ms = state.poll_rate_ms;
         response.lang = state.languageCode || 'en';
         response.returnURL = state.returnURL;
-        response.returnUrl = state.returnURL;
         response.oauthState = state.oauthState;
         response.clientData = state.clientData;
       } else if (state.status === 'ACCEPTED') {
@@ -159,11 +134,14 @@ export default function (expressApp: any, app: any) {
         response.token = state.token;
         response.apiEndpoint = state.apiEndpoint;
       } else if (state.status === 'REFUSED' || state.status === 'ERROR') {
-        response.reasonID = state.reasonID;
+        response.reasonId = state.reasonId;
         response.message = state.message;
       } else if (state.status === 'REDIRECTED') {
-      // Multi-core: auth moved to another core, follow the new poll URL
+        // Multi-core: auth moved to another core; the SDK follows the
+        // new poll URL. The auth UI receives the same field via the
+        // POST update response and redirects the browser.
         response.poll = state.redirectUrl;
+        response.redirectUrl = state.redirectUrl;
       }
 
       res.status(state.code).json(response);
@@ -207,18 +185,18 @@ export default function (expressApp: any, app: any) {
       }
 
       const response: any = {
-        status: state.status,
-        code: state.code
+        status: state.status
       };
       if (state.status === 'ACCEPTED') {
         response.username = state.username;
         response.token = state.token;
         response.apiEndpoint = state.apiEndpoint;
       } else if (state.status === 'REFUSED' || state.status === 'ERROR') {
-        response.reasonID = state.reasonID;
+        response.reasonId = state.reasonId;
         response.message = state.message;
       } else if (state.status === 'REDIRECTED') {
         response.poll = state.redirectUrl;
+        response.redirectUrl = state.redirectUrl;
       }
       res.status(state.code).json(response);
     } catch (err) { next(err); }

--- a/components/api-server/test/events.get-streams-query.test.js
+++ b/components/api-server/test/events.get-streams-query.test.js
@@ -9,7 +9,6 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 /* global initTests, initCore, coreRequest, getNewFixture, assert, cuid */
 
-const eventsQueryUtils = require('mall/src/helpers/eventsQueryUtils.ts');
 const streamsQueryUtils = require('../src/methods/helpers/streamsQueryUtils.ts');
 const { storeDataUtils } = require('mall');
 
@@ -270,7 +269,6 @@ describe('[EGSQ] events.get streams query', function () {
         }
       });
     });
-
   });
 
   describe('[EQ06] GET /events with streams queries', function () {

--- a/components/api-server/test/reg-access.test.js
+++ b/components/api-server/test/reg-access.test.js
@@ -33,8 +33,6 @@ describe('[RGAC] Register access authorization', () => {
       assert.strictEqual(res.body.status, 'NEED_SIGNIN');
       assert.ok(res.body.key);
       assert.strictEqual(res.body.key.length, 16);
-      assert.strictEqual(res.body.requestingAppId, 'test-app');
-      assert.deepStrictEqual(res.body.requestedPermissions, [{ streamId: 'diary', level: 'read' }]);
       assert.ok(res.body.poll);
       assert.strictEqual(res.body.poll_rate_ms, 1000);
     });
@@ -53,17 +51,21 @@ describe('[RGAC] Register access authorization', () => {
       assert.strictEqual(res.body.error.id, 'invalid-parameters');
     });
 
-    it('[RA04] must echo clientData and oauthState', async () => {
-      const res = await coreRequest.post('/reg/access')
+    it('[RA04] must echo clientData and oauthState on GET (NEED_SIGNIN poll)', async () => {
+      const postRes = await coreRequest.post('/reg/access')
         .send({
           requestingAppId: 'test-app',
           requestedPermissions: [{ streamId: 'diary', level: 'read' }],
           clientData: { foo: 'bar' },
           oauthState: 'xyz123'
         });
-      assert.strictEqual(res.status, 201);
-      assert.deepStrictEqual(res.body.clientData, { foo: 'bar' });
-      assert.strictEqual(res.body.oauthState, 'xyz123');
+      assert.strictEqual(postRes.status, 201);
+      // POST response is trimmed to the calling-app surface; clientData /
+      // oauthState live on the GET (auth UI consumer).
+      const getRes = await coreRequest.get('/reg/access/' + postRes.body.key);
+      assert.strictEqual(getRes.status, 201);
+      assert.deepStrictEqual(getRes.body.clientData, { foo: 'bar' });
+      assert.strictEqual(getRes.body.oauthState, 'xyz123');
     });
   });
 
@@ -160,12 +162,12 @@ describe('[RGAC] Register access authorization', () => {
       const refuseRes = await coreRequest.post('/reg/access/' + key)
         .send({
           status: 'REFUSED',
-          reasonID: 'USER_DENIED',
+          reasonId: 'USER_DENIED',
           message: 'User denied access'
         });
       assert.strictEqual(refuseRes.status, 403);
       assert.strictEqual(refuseRes.body.status, 'REFUSED');
-      assert.strictEqual(refuseRes.body.reasonID, 'USER_DENIED');
+      assert.strictEqual(refuseRes.body.reasonId, 'USER_DENIED');
     });
 
     it('[RA31] subsequent poll must return REFUSED state', async () => {
@@ -177,7 +179,7 @@ describe('[RGAC] Register access authorization', () => {
       const key = createRes.body.key;
 
       await coreRequest.post('/reg/access/' + key)
-        .send({ status: 'REFUSED', reasonID: 'USER_DENIED', message: 'No' });
+        .send({ status: 'REFUSED', reasonId: 'USER_DENIED', message: 'No' });
 
       const pollRes = await coreRequest.get('/reg/access/' + key);
       assert.strictEqual(pollRes.status, 403);
@@ -201,7 +203,7 @@ describe('[RGAC] Register access authorization', () => {
 
     it('[RA41] must return 400 for unknown key', async () => {
       const res = await coreRequest.post('/reg/access/nonexistentkey00')
-        .send({ status: 'REFUSED', reasonID: 'test', message: 'test' });
+        .send({ status: 'REFUSED', reasonId: 'test', message: 'test' });
       assert.strictEqual(res.status, 400);
     });
   });

--- a/components/api-server/test/reg-multicore-dnsless-false.test.js
+++ b/components/api-server/test/reg-multicore-dnsless-false.test.js
@@ -309,7 +309,7 @@ describe('[RGMD] register: multi-core (dnsLess=false path)', function () {
       request = supertest(app.expressApp);
     });
 
-    it('[MC14] POST /reg/access returns authUrl, poll, lang, serviceInfo, url (deprecated)', async function () {
+    it('[MC14] POST /reg/access returns {status, key, authUrl, poll, poll_rate_ms}', async function () {
       const res = await request.post('/reg/access').send({
         requestingAppId: 'test-app',
         requestedPermissions: [{ streamId: '*', level: 'read' }]
@@ -322,18 +322,21 @@ describe('[RGMD] register: multi-core (dnsLess=false path)', function () {
       assert.ok(body.poll.startsWith(buildCoreUrl(CORE_A)),
         'poll URL must be core-affine (pointing at this core): ' + body.poll);
       assert.strictEqual(typeof body.poll_rate_ms, 'number', 'must return poll_rate_ms');
-      assert.strictEqual(body.lang, 'en', 'must return lang (default en)');
       // authUrl is populated only when access.defaultAuthUrl is configured.
-      // With no config, authUrl is null — acceptable; real deployments always set it.
       if (body.authUrl) {
-        assert.strictEqual(body.url, body.authUrl, 'url (deprecated) must equal authUrl');
         assert.ok(body.authUrl.includes('key=' + body.key),
           'authUrl must include the key query param');
         assert.ok(body.authUrl.includes('poll='),
           'authUrl must include the poll query param');
       }
-      assert.ok(body.serviceInfo, 'must return serviceInfo');
-      assert.ok(body.serviceInfo.name, 'serviceInfo.name must be set');
+      // Calling-app surface is trimmed — service metadata + echoed input
+      // fields live on the GET poll path (used by the auth UI). The SDK
+      // resolves service metadata from `/service/info` if it needs it.
+      assert.strictEqual(body.serviceInfo, undefined);
+      assert.strictEqual(body.url, undefined);
+      assert.strictEqual(body.lang, undefined);
+      assert.strictEqual(body.requestingAppId, undefined);
+      assert.strictEqual(body.requestedPermissions, undefined);
     });
 
     it('[MC15] GET /reg/access/:key NEED_SIGNIN response includes poll, authUrl, serviceInfo', async function () {

--- a/justfile
+++ b/justfile
@@ -185,11 +185,21 @@ clean-test-data:
     # both pryv-node-test (test harness) AND pryv-node (local dev /
     # bin/master.js). Tests re-run migrations on next startup; the
     # local server runs them on next master boot.
+    # Wrap dropdb/createdb in `timeout` (GNU coreutils on Linux; absent on
+    # default macOS) so a misbehaving PG (held connections, auth prompt
+    # waiting on stdin, …) can't hang the whole recipe — observed on CI
+    # runners as 38-minute silent stalls. Darwin operators skip the wrapper
+    # since they typically don't share the runner's flakiness profile.
+    if command -v timeout >/dev/null 2>&1; then
+      TIMEOUT="timeout 30"
+    else
+      TIMEOUT=""
+    fi
     if [ -n "$DROPDB" ] && [ -n "$CREATEDB" ]; then
-      ("$DROPDB" -h 127.0.0.1 -p 5432 -U pryv --if-exists pryv-node-test 2>/dev/null && \
-          "$CREATEDB" -h 127.0.0.1 -p 5432 -U pryv pryv-node-test 2>/dev/null) || echo "PostgreSQL not reachable (skipping pg test reset)"
-      ("$DROPDB" -h 127.0.0.1 -p 5432 -U pryv --if-exists pryv-node 2>/dev/null && \
-          "$CREATEDB" -h 127.0.0.1 -p 5432 -U pryv pryv-node 2>/dev/null) || echo "PostgreSQL not reachable (skipping pg dev reset)"
+      ($TIMEOUT "$DROPDB" -h 127.0.0.1 -p 5432 -U pryv --if-exists --force pryv-node-test 2>/dev/null && \
+          $TIMEOUT "$CREATEDB" -h 127.0.0.1 -p 5432 -U pryv pryv-node-test 2>/dev/null) || echo "PostgreSQL not reachable (skipping pg test reset)"
+      ($TIMEOUT "$DROPDB" -h 127.0.0.1 -p 5432 -U pryv --if-exists --force pryv-node 2>/dev/null && \
+          $TIMEOUT "$CREATEDB" -h 127.0.0.1 -p 5432 -U pryv pryv-node 2>/dev/null) || echo "PostgreSQL not reachable (skipping pg dev reset)"
     else
       echo "dropdb/createdb not found (skipping pg test reset + pg dev reset)"
     fi

--- a/scripts/setup-dev-env
+++ b/scripts/setup-dev-env
@@ -35,18 +35,13 @@ mkdir -p $LOGS_FOLDER
 export ATTACHMENTS_FOLDER=$VAR_PRYV_FOLDER/attachments
 mkdir -p $ATTACHMENTS_FOLDER
 
-# database
+# Base storage engines: PostgreSQL (default) + SQLite (alternative) — no
+# system-level setup step is required here. CI provides PostgreSQL via the
+# GitHub Actions services container; local dev compiles PG from source by
+# invoking storages/engines/postgresql/scripts/setup directly when needed.
+# SQLite has no setup step (npm install handles better-sqlite3).
 
 REPO_ROOT="$(pwd)"
-. storages/engines/mongodb/scripts/setup
-EXIT_CODE=$?
-cd "$REPO_ROOT"
-if [[ ${EXIT_CODE} -ne 0 ]]; then
-  echo ""
-  echo "Error setting up MongoDB; setup aborted"
-  echo ""
-  exit ${EXIT_CODE}
-fi
 
 # platform DB (rqlite — mandatory since v2)
 


### PR DESCRIPTION
## Summary

Trims the `/reg/access` polling endpoints' response shapes to the fields each consumer audience actually reads.

**`POST /reg/access`** (SDK-facing) — returns only `{ status, key, authUrl, poll, poll_rate_ms }`. Removed: `code`, `url` (v1 alias of `authUrl`), `returnUrl` (camelCase duplicate of `returnURL`), `requestingAppId`, `requestedPermissions`, `lang`, `returnURL`, `oauthState`, `clientData`, `serviceInfo`. The auth UI gets these via `GET /reg/access/:key`; SDKs fetch service metadata from `/service/info` directly.

**`GET /reg/access/:key`** — `code` dropped from the body; `url` / `returnUrl` deprecated aliases dropped on `NEED_SIGNIN`. `serviceInfo` is now embedded only on `NEED_SIGNIN` polls (the only response the auth UI consumes for that field).

**`REDIRECTED`** state — emits both `poll` (back-compat) and a new explicit `redirectUrl` field so consumers don't have to overload the polling field.

**`reasonID` → `reasonId`** — the uppercase-D spelling was emitted but never read; every consumer that actually reads it (`app-web-auth3`, downstream apps) expects `reasonId`. Renamed on both inputs and outputs.

## Test plan

- [x] `just lint-changes` — clean
- [x] `just test api-server --grep RGAC` — 13/0 (reg-access)
- [x] `just test api-server --grep MC04` — 4/0 (REDIRECTED multi-core)
- [x] `just test api-server --grep MC14` — 1/0 (POST shape)
- [x] `just test api-server --grep MC15` — 1/0 (GET shape)
- [x] **Full sequential PG matrix: `just test all` — 2344 passing, 0 failing, 7 pending**

## Coordinated release

This PR is **one of three** that ship together for the auth-flow surface narrowing:
- `pryv/lib-js#69` — SDK-side narrowing (`pryv@3.5.0`)
- `pryv/app-web-auth3#69` — auth UI alignment + `?cli=1`

`CHANGELOG-v2.md` documents the wire-format changes and the migration path for SDKs on `pryv@<3.5.0`. Recommended deploy order: lib-js + app-web-auth3 first, then this server change.