### PR TITLE
Add pryvio/open-pryv.io-encrypted image variant (encryption at rest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,3 +163,18 @@ jobs:
           tags: |
             pryvio/open-pryv.io:${{ github.ref_name }}
             pryvio/open-pryv.io:2.0.0-pre
+      # Encryption-at-rest variant: layers the container-encrypted-volume payload
+      # onto the stock image just pushed above (base image unchanged; encryption
+      # opt-in via CEV_ENABLED at runtime). Pulls the payload from ghcr, which
+      # must be public (or add a ghcr docker/login-action step here).
+      - name: Build + push encryption-at-rest variant
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.encrypted
+          push: true
+          build-args: |
+            IMAGE_TAG=${{ github.ref_name }}
+          tags: |
+            pryvio/open-pryv.io-encrypted:${{ github.ref_name }}
+            pryvio/open-pryv.io-encrypted:2.0.0-pre

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,8 @@ jobs:
             pryvio/open-pryv.io:2.0.0-pre
       # Encryption-at-rest variant: layers the container-encrypted-volume payload
       # onto the stock image just pushed above (base image unchanged; encryption
-      # opt-in via CEV_ENABLED at runtime). Pulls the payload from ghcr, which
-      # must be public (or add a ghcr docker/login-action step here).
+      # opt-in via CEV_ENABLED at runtime). The payload is pulled from Docker Hub
+      # (pryvio/container-encrypted-volume), public + same registry as this image.
       - name: Build + push encryption-at-rest variant
         uses: docker/build-push-action@v7
         with:

--- a/Dockerfile.encrypted
+++ b/Dockerfile.encrypted
@@ -9,8 +9,9 @@
 # data roots under CEV_MOUNT via override-config, and run with --privileged (LUKS).
 # See INSTALL.md "Encryption at rest" and the companion's docs/OPERATING.md.
 #
-# Prerequisite: the payload image ghcr.io/pryv/container-encrypted-volume must be
-# pullable (public, or the builder authenticated to ghcr).
+# The payload image pryvio/container-encrypted-volume is public on Docker Hub
+# (same registry + org as this image), so the build pulls it with the Docker Hub
+# auth the release job already has.
 ARG IMAGE_TAG=2.0.0-pre
 FROM pryvio/open-pryv.io:${IMAGE_TAG}
 
@@ -19,7 +20,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends cryptsetup e2fsprogs openssl ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-COPY --from=ghcr.io/pryv/container-encrypted-volume:v0.1.0 /cev /opt/cev
+COPY --from=pryvio/container-encrypted-volume:v0.1.1 /cev /opt/cev
 
 ENV CEV_ENABLED=false \
     CEV_BACKEND=luks \

--- a/Dockerfile.encrypted
+++ b/Dockerfile.encrypted
@@ -1,0 +1,33 @@
+# Encryption-at-rest variant of pryvio/open-pryv.io.
+#
+# Layers the `container-encrypted-volume` payload onto the stock image — the base
+# image is NOT modified. Encryption is OFF by default (CEV_ENABLED=false), so this
+# image boots exactly like the stock one until an operator opts in; the wrapper is
+# then a transparent pass-through to the normal entrypoint.
+#
+# To enable at runtime: set CEV_ENABLED=true, choose a key provider, relocate the
+# data roots under CEV_MOUNT via override-config, and run with --privileged (LUKS).
+# See INSTALL.md "Encryption at rest" and the companion's docs/OPERATING.md.
+#
+# Prerequisite: the payload image ghcr.io/pryv/container-encrypted-volume must be
+# pullable (public, or the builder authenticated to ghcr).
+ARG IMAGE_TAG=2.0.0-pre
+FROM pryvio/open-pryv.io:${IMAGE_TAG}
+
+USER root
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends cryptsetup e2fsprogs openssl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/pryv/container-encrypted-volume:v0.1.0 /cev /opt/cev
+
+ENV CEV_ENABLED=false \
+    CEV_BACKEND=luks \
+    CEV_KEY_PROVIDER=env \
+    CEV_CONTAINER=/app/var-pryv/encrypted/data.img \
+    CEV_MOUNT=/app/var-pryv/encrypted/mnt \
+    CEV_SIZE_GIB=50 \
+    CEV_EXEC=/app/scripts/docker-entrypoint.sh
+
+ENTRYPOINT ["/opt/cev/entrypoint-wrapper.sh"]
+CMD []

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -352,6 +352,60 @@ server {
 | `data/previews/` | Generated image previews |
 | `data/rqlite-data/` | Platform DB (rqlite Raft log + SQLite snapshot) |
 
+## Encryption at rest (optional)
+
+By default the data directories above are stored as plaintext on disk; encrypting
+the underlying volume is the operator's responsibility (host full-disk encryption,
+cloud-disk encryption, or PostgreSQL TDE for external PG). Platform *secrets*
+(Let's Encrypt account keys, observability tokens, cluster bootstrap bundles) are
+always encrypted at rest (AES-256-GCM).
+
+For a turnkey option, a separately published image variant
+**`pryvio/open-pryv.io-encrypted`** layers the
+[`container-encrypted-volume`](https://github.com/pryv/container-encrypted-volume)
+facility onto the stock image. It provisions and mounts an encrypted volume inside
+the container on boot, so the data directories sit on ciphertext at rest. It is
+**off by default** (`CEV_ENABLED=false`) — the variant boots exactly like the stock
+image until you opt in — and the stock `pryvio/open-pryv.io` image is unchanged.
+
+What it protects: stolen / decommissioned disks, off-host volume backups,
+snapshots. It does **not** protect a running container (that is access control's
+job). It satisfies the encryption-at-rest expectations of HIPAA §164.312(a)(2)(iv)
+and GDPR Art.32(1)(a).
+
+To enable (LUKS backend shown):
+
+```bash
+docker run --privileged \
+  -e CEV_ENABLED=true \
+  -e CEV_KEY_PROVIDER=aws-kms -e CEV_KMS_BLOB=/run/secrets/cev.blob -e CEV_AWS_REGION=eu-central-2 \
+  -v pryv-encrypted:/app/var-pryv/encrypted \
+  -v "$PWD/override-config.yml":/app/config/override-config.yml:ro \
+  -p 3000:3000 \
+  pryvio/open-pryv.io-encrypted:<tag>
+```
+
+Then relocate the data roots onto the encrypted mount in your `override-config.yml`
+(they support `${ENV}` interpolation; do **not** reuse `/app/var-pryv/rqlite-data`,
+which is a declared `VOLUME`):
+
+```yaml
+storages:
+  base:   { engine: sqlite }      # SQLite base storage lands on the mount
+  engines:
+    sqlite:     { path: /app/var-pryv/encrypted/mnt/users }
+    filesystem: { attachmentsDirPath: /app/var-pryv/encrypted/mnt/attachments }
+    rqlite:     { dataDir: /app/var-pryv/encrypted/mnt/rqlite-data }
+```
+
+Notes:
+- LUKS needs `--privileged` (or `--cap-add SYS_ADMIN` + device mappings); restricted
+  Kubernetes Pod Security profiles may forbid it — use host-side FDE there instead.
+- An **external** PostgreSQL data dir and remote S3 attachments are outside this
+  mount — encrypt those operator-side / with bucket SSE.
+- Key custody, rotation, and disaster recovery (key lost = data lost) are covered in
+  the companion's [`docs/OPERATING.md`](https://github.com/pryv/container-encrypted-volume/blob/master/docs/OPERATING.md).
+
 ## Docker / Dokku deployment
 
 ### What to persist


### PR DESCRIPTION
Optional encryption-at-rest as a separately-published image variant, layered onto the stock image. The base `pryvio/open-pryv.io` image is **unchanged**; encryption is **off by default** (`CEV_ENABLED=false`) so the variant boots identically until opted in.

- **Dockerfile.encrypted** — `FROM` the stock image + the [container-encrypted-volume](https://github.com/pryv/container-encrypted-volume) payload (ghcr, pinned `v0.1.0`) + the wrapper entrypoint.
- **ci.yml** — on tag push, build + push `pryvio/open-pryv.io-encrypted:<tag>` + `:2.0.0-pre` alongside the stock image.
- **INSTALL.md** — new "Encryption at rest (optional)" section: threat model, enable recipe, data-root relocation via override-config, caveats, DR pointer.

**Prerequisite:** the payload image `ghcr.io/pryv/container-encrypted-volume` must be public (or add a ghcr login step to the docker job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)