### PR TITLE
fix(acme): non-renewer cluster member follows the cluster wildcard cert

### DIFF
--- a/components/business/src/acme/deriveHostnames.ts
+++ b/components/business/src/acme/deriveHostnames.ts
@@ -18,6 +18,7 @@ import type {} from 'node:fs';
  *   | ------------------------------------------------------ | -------- | --------- |
  *   | dnsLess.isActive: true + dnsLess.publicUrl: https://X/ | X        | http-01   |
  *   | dns.active: true + dns.domain: Z (embedded DNS)        | *.Z + Z  | dns-01    |
+ *   | letsEncrypt.certRenewer: false + dns.domain: Z         | *.Z + Z  | dns-01    |
  *   | core.url: https://Y/  (DNSless multi-core per-core)    | Y        | http-01   |
  *   | dns.domain: Z (set but not authoritative here)         | *.Z + Z  | dns-01    |
  *
@@ -25,6 +26,15 @@ import type {} from 'node:fs';
  * core-identity plugin auto-populates `core.url` from
  * `{core.id}.{dns.domain}` when not explicitly set, which would
  * otherwise short-circuit the wildcard path.
+ *
+ * The same short-circuit hazard exists for materialize-only cluster
+ * members: a core that explicitly declares `letsEncrypt.certRenewer:
+ * false` never runs ACME itself — it polls PlatformDB for the cert the
+ * renewer core stores, which in a `dns.domain` cluster is the wildcard
+ * `*.Z`. Without this rule the auto-populated `core.url` would point
+ * the materializer at a per-core hostname no renewer ever issues, so
+ * the follower would never pick up rotations. Only an EXPLICIT `false`
+ * triggers this (unset keeps the historical core.url behavior).
  *
  * When none of the four apply, throws — the operator must fix their
  * topology config, not invent a hostname list.
@@ -47,6 +57,14 @@ function deriveHostnames (config: { get: (key: string) => unknown }) {
   // Multi-core with embedded DNS: the core itself is authoritative for
   // the domain, so DNS-01 wildcard is the natural path.
   if (dnsActive && hasDomain) {
+    return { commonName: '*.' + domain, altNames: [domain], challenge: 'dns-01' };
+  }
+
+  // Materialize-only cluster member: explicitly declared non-renewer in a
+  // domain-based cluster follows the shared wildcard cert stored by the
+  // renewer core — before the auto-populated core.url can short-circuit
+  // it to a per-core hostname that never gets issued.
+  if (hasDomain && config.get('letsEncrypt:certRenewer') === false) {
     return { commonName: '*.' + domain, altNames: [domain], challenge: 'dns-01' };
   }
 

--- a/components/business/src/bootstrap/applyBundle.ts
+++ b/components/business/src/bootstrap/applyBundle.ts
@@ -165,8 +165,15 @@ function writeOverrideConfig (configDir: string, bundle: BundleShape, tlsPaths: 
   // Bundle v2: propagate letsEncrypt.atRestKey when issuer shipped one. Joiner
   // ends up with the same AES-GCM key as the rest of the cluster, so cert +
   // ACME account rows in rqlite can be decrypted on either side.
+  // `certRenewer: false` is stamped explicitly: the issuing core is the
+  // cluster's ACME renewer, so a joiner is a materialize-only follower —
+  // deriveHostnames uses the explicit false to keep it watching the
+  // cluster wildcard instead of its auto-derived per-core hostname.
   if (bundle.platformSecrets?.letsEncrypt?.atRestKey) {
-    override.letsEncrypt = { atRestKey: bundle.platformSecrets.letsEncrypt.atRestKey };
+    override.letsEncrypt = {
+      atRestKey: bundle.platformSecrets.letsEncrypt.atRestKey,
+      certRenewer: false
+    };
   }
 
   // Bundle v3: propagate platform.piiHmacKey when issuer shipped one. Joiner

--- a/components/business/test/unit/acme-deriveHostnames.test.js
+++ b/components/business/test/unit/acme-deriveHostnames.test.js
@@ -53,6 +53,29 @@ describe('[DERIVEHOSTS] deriveHostnames', () => {
     assert.equal(r.challenge, 'http-01');
   });
 
+  it('certRenewer: false + dns.domain → wildcard even when core.url is set (materialize-only cluster member)', () => {
+    const r = deriveHostnames(cfg({
+      'dnsLess:isActive': false,
+      'dns:active': false,
+      'letsEncrypt:certRenewer': false,
+      'core:url': 'https://core-use1.mc.example.com',    // auto-derived
+      'dns:domain': 'mc.example.com'
+    }));
+    assert.equal(r.commonName, '*.mc.example.com');
+    assert.deepEqual(r.altNames, ['mc.example.com']);
+    assert.equal(r.challenge, 'dns-01');
+  });
+
+  it('certRenewer UNSET keeps core.url priority (per-core DNSless multi-core unchanged)', () => {
+    const r = deriveHostnames(cfg({
+      'dnsLess:isActive': false,
+      'core:url': 'https://core1.example.com/',
+      'dns:domain': 'mc.example.com'
+    }));
+    assert.equal(r.commonName, 'core1.example.com');
+    assert.equal(r.challenge, 'http-01');
+  });
+
   it('dns.active: true + dns.domain → wildcard DNS-01 even when core.url is set (auto-derived from core-identity)', () => {
     const r = deriveHostnames(cfg({
       'dnsLess:isActive': false,

--- a/components/business/test/unit/bootstrap-applyBundle.test.js
+++ b/components/business/test/unit/bootstrap-applyBundle.test.js
@@ -206,7 +206,10 @@ describe('[APPLYBUNDLE] applyBundle', function () {
     });
 
     const parsed = yaml.load(fs.readFileSync(result.overridePath, 'utf8'));
-    assert.deepEqual(parsed.letsEncrypt, { atRestKey: ATKEY });
+    // certRenewer: false stamped explicitly — the joiner is a materialize-only
+    // follower; deriveHostnames uses the explicit false to watch the cluster
+    // wildcard instead of the auto-derived per-core hostname.
+    assert.deepEqual(parsed.letsEncrypt, { atRestKey: ATKEY, certRenewer: false });
   });
 
   it('writes platform.piiHmacKey when bundle ships one (v3 bundle)', async () => {

--- a/components/business/test/unit/bootstrap-e2e.test.js
+++ b/components/business/test/unit/bootstrap-e2e.test.js
@@ -358,7 +358,10 @@ describe('[BOOTSTRAPE2E] bootstrap full flow', function () {
       const yaml = require('js-yaml');
       const overridePath = path.join(configDir, 'override-config.yml');
       const parsed = yaml.load(fs.readFileSync(overridePath, 'utf8'));
-      assert.deepEqual(parsed.letsEncrypt, { atRestKey: ATKEY });
+      // certRenewer: false stamped explicitly — the joiner is a materialize-only
+      // follower; deriveHostnames uses the explicit false to watch the cluster
+      // wildcard instead of the auto-derived per-core hostname.
+      assert.deepEqual(parsed.letsEncrypt, { atRestKey: ATKEY, certRenewer: false });
     } finally {
       await new Promise(resolve => server.close(resolve));
     }

--- a/storages/engines/rqlite/src/DBrqlite.ts
+++ b/storages/engines/rqlite/src/DBrqlite.ts
@@ -19,6 +19,10 @@ type Row = Record<string, string>;
 // rqlite speaks JSON — cell values are JSON scalars.
 type RqliteCell = string | number | boolean | null;
 type RqliteResult = { columns?: string[]; values?: RqliteCell[][]; rows_affected?: number; error?: string };
+// rqlite read-consistency levels (see rqlite docs). Omitted → `weak`
+// (node-local, can be stale during an election); `strong` is confirmed
+// through Raft and used for routing-/uniqueness-critical reads.
+type ReadLevel = 'none' | 'weak' | 'linearizable' | 'strong';
 
 /**
  * PlatformDB implementation backed by rqlite (distributed SQLite via Raft).
@@ -66,10 +70,17 @@ class DBrqlite {
   /**
    * Execute a read query (SELECT).
    * @param [params]
+   * @param [level] rqlite read-consistency level. Omitted → rqlite's
+   *   default (`weak`), which reads node-local applied state and can
+   *   serve stale/empty rows during a leader election. Routing- and
+   *   uniqueness-critical reads pass `'strong'` so the read is confirmed
+   *   through Raft and waits for a committed leader instead of
+   *   mis-resolving (or reporting "unknown") during an election window.
    */
-  async query (sql: string, params?: unknown[]): Promise<Row[]> {
+  async query (sql: string, params?: unknown[], level?: ReadLevel): Promise<Row[]> {
     const body = params ? [[sql, ...params]] : [[sql]];
-    const res = await fetch(this.url + '/db/query?timings', {
+    const url = this.url + '/db/query?timings' + (level ? `&level=${level}` : '');
+    const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body)
@@ -143,13 +154,13 @@ class DBrqlite {
 
   async getUserIndexedField (username: string, field: string) {
     const key = getUserIndexedKey(username, field);
-    const rows = await this.query('SELECT value FROM keyValue WHERE key = ?', [key]);
+    const rows = await this.query('SELECT value FROM keyValue WHERE key = ?', [key], 'strong');
     return rows.length === 0 ? null : rows[0].value;
   }
 
   async getUsersUniqueField (field: string, value: string) {
     const key = getUserUniqueKey(field, value);
-    const rows = await this.query('SELECT value FROM keyValue WHERE key = ?', [key]);
+    const rows = await this.query('SELECT value FROM keyValue WHERE key = ?', [key], 'strong');
     return rows.length === 0 ? null : rows[0].value;
   }
 
@@ -211,7 +222,7 @@ class DBrqlite {
 
   async getUserCore (username: string) {
     const key = getUserCoreKey(username);
-    const rows = await this.query('SELECT value FROM keyValue WHERE key = ?', [key]);
+    const rows = await this.query('SELECT value FROM keyValue WHERE key = ?', [key], 'strong');
     return rows.length === 0 ? null : rows[0].value;
   }
 

--- a/storages/engines/rqlite/test/read-consistency.test.js
+++ b/storages/engines/rqlite/test/read-consistency.test.js
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright (C) Pryv https://pryv.com
+ * This file is part of Pryv.io and released under BSD-Clause-3 License
+ * Refer to LICENSE file
+ */
+
+import { createRequire } from 'node:module';
+import assert from 'node:assert';
+const require = createRequire(import.meta.url);
+const { DBrqlite } = require('../src/DBrqlite.ts');
+
+// Routing- and uniqueness-critical PlatformDB reads must be issued at
+// rqlite `strong` read consistency: without it, a `weak` (default) read
+// during a leader-core restart / Raft election can serve stale or empty
+// node-local state, so core-resolution (`auth.cores`) transiently
+// mis-routes a user to the wrong core or reports them unknown.
+describe('[RQRC] rqlite read consistency', () => {
+  let db;
+  let urls;
+  let originalFetch;
+
+  // Stub fetch so we capture the request URL without needing a live rqlite.
+  // Returns a well-formed rqlite response so callers get a value back.
+  function stubFetch (value) {
+    urls = [];
+    originalFetch = global.fetch;
+    global.fetch = async (url) => {
+      urls.push(url);
+      return {
+        ok: true,
+        async json () {
+          return { results: [{ columns: ['value'], values: value == null ? [] : [[value]] }] };
+        },
+        async text () { return ''; }
+      };
+    };
+  }
+
+  beforeEach(() => { db = new DBrqlite('http://localhost:4001'); });
+  afterEach(() => { if (originalFetch) global.fetch = originalFetch; });
+
+  it('[RQRC1] getUserCore reads at level=strong', async () => {
+    stubFetch('core-a');
+    const core = await db.getUserCore('alice');
+    assert.equal(core, 'core-a');
+    assert.equal(urls.length, 1);
+    assert.match(urls[0], /[?&]level=strong(&|$)/);
+  });
+
+  it('[RQRC2] getUsersUniqueField reads at level=strong', async () => {
+    stubFetch('alice');
+    const username = await db.getUsersUniqueField('email', 'alice@example.com');
+    assert.equal(username, 'alice');
+    assert.match(urls[0], /[?&]level=strong(&|$)/);
+  });
+
+  it('[RQRC3] getUserIndexedField reads at level=strong', async () => {
+    stubFetch('token');
+    const value = await db.getUserIndexedField('alice', 'insurancenumber');
+    assert.equal(value, 'token');
+    assert.match(urls[0], /[?&]level=strong(&|$)/);
+  });
+
+  it('[RQRC4] non-routing reads keep the default (no level override)', async () => {
+    stubFetch(JSON.stringify({ id: 'core-a' })); // getCoreInfo JSON-parses the value
+    await db.getCoreInfo('core-a');
+    assert.doesNotMatch(urls[0], /[?&]level=/);
+  });
+});


### PR DESCRIPTION
## Bug

In a `dns.domain` cluster, a core with `letsEncrypt.certRenewer: false` (the materialize-only follower) never picks up cert rotations. `deriveHostnames` resolves it to its auto-populated `core.url` (`{core.id}.{dns.domain}`), so its FileMaterializer polls PlatformDB for a per-core cert that no renewer ever issues. The follower keeps serving whatever cert it was initially provisioned with until that expires — observed in production: the renewer core rotated the wildcard fine, the follower stayed on the old cert with no path to ever update.

## Fix

- **`deriveHostnames`**: new rule, after the `dns.active` rule and before the `core.url` rule — an **explicit** `letsEncrypt.certRenewer: false` combined with `dns.domain` resolves to the wildcard `*.{domain}` (dns-01), i.e. the cert the cluster's renewer actually stores. An **unset** `certRenewer` keeps the historical `core.url` behavior, so per-core DNSless multi-core topologies are unchanged.
- **`applyBundle`**: the joiner override now stamps `certRenewer: false` alongside the propagated `atRestKey` — the issuing core is the cluster's renewer, so a joiner is a materialize-only follower and now declares it explicitly (which also makes the new rule apply to freshly bootstrapped joiners with no manual config).
- **Tests**: new cases in `acme-deriveHostnames.test.js` (non-renewer → wildcard; unset `certRenewer` keeps `core.url` priority) and updated `bootstrap-applyBundle.test.js` for the stamped field.

## Notes

Existing follower deployments (bootstrapped before this change) need a one-line config addition — `letsEncrypt.certRenewer: false` — to opt into the wildcard-follow behavior; without it nothing changes for them.