### PR TITLE
oauth2: refresh-token reuse detection with chain revocation

### DIFF
--- a/components/api-server/src/routes/oauth2.ts
+++ b/components/api-server/src/routes/oauth2.ts
@@ -48,6 +48,13 @@ const { parseAccessRef } = require('business/src/accesses/refs.ts');
 // Tree-aware consent guard: closes the hierarchical-masking gap that the
 // pure entry-subset check (checkConsentGrant, run at /accept) cannot see.
 const { assertGrantedWithinOffer } = require('business/src/accesses/consentEffectiveGuard.ts');
+// Reuse-detection chain-revoke deps (mirror the accesses.delete method chain).
+const cache = require('cache').default;
+const { pubsub } = require('messages');
+const { fromCallback } = require('utils');
+const WebhooksRepository = require('business').webhooks.Repository;
+// CMC back-channel revoke notify — pure DI HTTP sender, no MethodContext needed.
+const { outbound: cmcOutbound } = require('cmc');
 
 /** Trigger-scope parent for OAuth-driven CMC accepts on the user's account. */
 const OAUTH_CMC_PARENT = ':_cmc:apps:oauth';
@@ -76,15 +83,25 @@ type OAuthMethodResult = {
 /** A CMC data-grant access row, as read back from accesses.get / findOne. */
 type DataGrant = {
   id: string;
+  token?: unknown;
   permissions?: Array<Record<string, unknown>>;
   deleted?: unknown;
   expires?: number | null;
-  clientData?: { cmc?: { role?: string; offerEventId?: string; acceptEventId?: string } };
+  createdBy?: unknown;
+  // Widened vs the narrow role/offer view: reuse-detection reads the CMC
+  // counterparty back-channel address off the data-grant to notify the app.
+  clientData?: { cmc?: {
+    role?: string; offerEventId?: string; acceptEventId?: string;
+    counterparty?: { apiEndpoint?: string };
+    backChannelApiEndpoint?: string;
+  } };
 };
 
 /** The storage-layer accesses repository surface this module calls directly. */
 type AccessesRepo = {
   findOne: (user: { id: string; username: string }, query: Record<string, unknown>, opts: unknown, cb: (err: unknown, found: DataGrant | null) => void) => void;
+  find: (user: { id: string; username: string }, query: Record<string, unknown>, opts: unknown, cb: (err: unknown, found: DataGrant[] | null) => void) => void;
+  delete: (user: { id: string; username: string }, query: Record<string, unknown>, cb: (err: unknown) => void) => void;
   insertOne: (user: { id: string; username: string }, row: Record<string, unknown>, cb: (err: unknown, created: { id?: unknown; token?: unknown } | null) => void) => void;
   generateToken: () => string;
 };
@@ -475,12 +492,120 @@ export default function mountOAuth2 (expressApp: ExpressApp, app: AppLike): void
     });
   }
 
+  // ---------------------------------------------------------------------
+  // revokeChain — collapse a refresh chain on detected reuse. Storage-direct:
+  // soft-delete the durable data-grant + all live oauth session accesses for
+  // (user, client) + their descendants, cascade webhooks, invalidate the access
+  // cache cluster-wide, then best-effort notify the counterparty app. Mirrors
+  // the accesses.delete method chain's teardown without a MethodContext.
+  // ---------------------------------------------------------------------
+  async function revokeChain ({ userId, username, clientId, dataGrantAccessId }: {
+    userId: string; username: string; clientId: string; dataGrantAccessId?: string;
+  }): Promise<void> {
+    const sl = storageLayer as { accesses?: AccessesRepo; webhooks?: unknown; events?: unknown };
+    const accessesRepository = sl.accesses;
+    if (accessesRepository == null) throw new Error('oauth2.revokeChain: storageLayer.accesses unavailable');
+    const user = { id: userId, username };
+
+    // 1. Read the data-grant head BEFORE deleting (need clientData.cmc for the
+    //    notify). Raw null-tolerant findOne — NOT readDataGrantHead, which throws
+    //    on exactly the deleted/expired state a revoke must tolerate.
+    let dataGrant: DataGrant | null = null;
+    if (dataGrantAccessId != null) {
+      const base = parseAccessRef(dataGrantAccessId).base;
+      dataGrant = await fromCallback((cb: (e: unknown, r: DataGrant | null) => void) =>
+        accessesRepository.findOne(user, { id: base }, null, cb));
+    }
+
+    // 2. Collect the delete set: data-grant head + live oauth session accesses +
+    //    their descendants (a stolen app session can mint shared sub-accesses;
+    //    leaving them alive = incomplete revoke). Dedup by id; skip already-deleted.
+    const ids = new Set<string>();
+    if (dataGrant != null && typeof dataGrant.id === 'string') ids.add(dataGrant.id);
+    const sessions: DataGrant[] = (await fromCallback((cb: (e: unknown, r: DataGrant[] | null) => void) =>
+      accessesRepository.find(user, { type: 'app', name: 'oauth:' + clientId, deleted: null }, null, cb))) ?? [];
+    for (const s of sessions) if (typeof s.id === 'string') ids.add(s.id);
+    for (const id of [...ids]) {
+      const kids: DataGrant[] = (await fromCallback((cb: (e: unknown, r: DataGrant[] | null) => void) =>
+        accessesRepository.find(user, { createdBy: id, deleted: null }, null, cb))) ?? [];
+      for (const k of kids) if (typeof k.id === 'string') ids.add(k.id);
+    }
+    const idList = [...ids];
+
+    // 3. Webhooks cascade BEFORE the delete (retry-safe), then soft-delete all ids.
+    const webhooksRepository = new WebhooksRepository(sl.webhooks, sl.events, sl.accesses);
+    for (const id of idList) {
+      try { await webhooksRepository.deleteByAccess(user, id); } catch (err: unknown) {
+        logger.warn('oauth2.revokeChain: webhook cascade failed for ' + id, err);
+      }
+    }
+    if (idList.length > 0) {
+      await fromCallback((cb: (e: unknown) => void) =>
+        accessesRepository.delete(user, { $or: idList.map((id) => ({ id })) }, cb));
+    }
+    // Parity gap vs accesses.delete: it also releases any `randomAlias` reservation
+    // carried by a deleted access. Not replicated here — oauth session/app accesses
+    // do not mint aliases, and the ALIASES primitive is not shipped, so no alias can
+    // leak today. Revisit if aliased descendants become reachable.
+
+    // 4. Cache invalidation (MANDATORY): the cache validates a token on `expires`
+    //    only, never `deleted`, so soft-deleted rows keep validating from cache.
+    //    unsetUserData clears every access-logic for the user cluster-wide,
+    //    covering sessions + descendants + the data-grant head (app-held token).
+    cache.unsetUserData(userId);
+    pubsub.notifications.emit(username, pubsub.USERNAME_BASED_ACCESSES_CHANGED);
+    await oauth2.emitAudit('oauth.token.revoked', { clientId, userId, reason: 'refresh-token reuse detected' });
+
+    // 5. CMC back-channel notify (best-effort; informational — the peer applies no
+    //    teardown to an inbound counterparty-role revoke, it learns at its next
+    //    failing refresh). apiEndpoint is null until the app completed the
+    //    back-channel handshake → skip quietly; delivery failure never rolls back.
+    const cmcCd = dataGrant?.clientData?.cmc;
+    const apiEndpoint = cmcCd?.counterparty?.apiEndpoint ?? cmcCd?.backChannelApiEndpoint;
+    if (typeof apiEndpoint === 'string' && apiEndpoint.length > 0) {
+      try {
+        // postToPeer returns a discriminated union — it does NOT throw on an HTTP
+        // or network failure, so check the result explicitly (the catch only sees
+        // apiEndpoint-parse throws). Best-effort: a failed notify never rolls back.
+        const delivery = await cmcOutbound.postToPeer({
+          apiEndpoint,
+          path: 'events',
+          body: { streamIds: [':_cmc:inbox'], type: 'consent/revoke-cmc', content: { from: { username, host: selfHost(username) }, reason: 'refresh-token-reuse' } },
+          deps: { fetch: (u: string, i: unknown) => globalThis.fetch(u, i as RequestInit), timeoutMs: 15000, logger },
+        });
+        if (delivery != null && delivery.ok === false) {
+          logger.warn('oauth2.revokeChain: CMC revoke notify not delivered', delivery);
+        }
+      } catch (err: unknown) { logger.warn('oauth2.revokeChain: CMC revoke notify failed', err); }
+    } else {
+      logger.debug('oauth2.revokeChain: data-grant has no counterparty apiEndpoint — CMC notify skipped');
+    }
+  }
+
+  // Self-identity host for the CMC notify `from` — mirrors cmcSelfIdentityFor:
+  // dns.domain → host of service.api/register → localhost. Resolve the per-user
+  // `{username}` template (DNS-per-user deploys) so the host is a real name, not
+  // a literal placeholder (new URL('https://{username}.pryv.me/') does not throw).
+  function selfHost (username: string): string {
+    const sub = (v: string): string => v.replace('{username}', username);
+    const dnsDomain = config.get('dns:domain');
+    if (typeof dnsDomain === 'string' && dnsDomain.length > 0) return sub(dnsDomain);
+    for (const key of ['service:api', 'service:register']) {
+      const url = config.get(key);
+      if (typeof url === 'string' && url.length > 0) {
+        try { return new URL(sub(url)).host; } catch { /* try next */ }
+      }
+    }
+    return 'localhost';
+  }
+
   oauth2.registerRoutes(expressApp, {
     config,
     platform: storages.platformDB,
     mintRefreshedAccess,
     mintClientAccess,
     resolveAccountUserId,
+    revokeChain,
     resolveUser,
     createAccess,
   });

--- a/components/api-server/test/oauth2-e2e.test.js
+++ b/components/api-server/test/oauth2-e2e.test.js
@@ -401,6 +401,22 @@ describe('[OAUTH-E2E] OAuth 2.0 authorization-code flow (granular consent-offer 
   });
 
   describe('[OAUTH-E2E-FAIL] negative cases', function () {
+    // A bare 404 out of /oauth2/authorize is ambiguous: route not mounted,
+    // client row missing from PlatformDB, or the consent-offer capability
+    // not resolving. Discriminate them up front so an intermittent failure
+    // in the cases below reports which prerequisite actually broke.
+    beforeEach(async function () {
+      const noParams = await coreRequest.get('/oauth2/authorize');
+      assert.notEqual(noParams.status, 404,
+        '/oauth2/authorize route not mounted: ' + describeRes(noParams));
+      const platformDB = require('storages').platformDB;
+      const clientRow = await storage.getClient(platformDB, clientId);
+      assert.ok(clientRow != null, 'OAuth client fixture missing from PlatformDB: ' + clientId);
+      const capRes = await globalThis.fetch(capabilityUrl);
+      assert.equal(capRes.status, 200,
+        'consent-offer capability URL does not resolve: ' + capabilityUrl + ' -> ' + capRes.status);
+    });
+
     it('[OE10] code reuse → invalid_grant on the second exchange', async function () {
       const r = await runFullFlow();
       assert.equal(r.tokenRes.status, 200);

--- a/components/audit/src/ApiMethods.ts
+++ b/components/audit/src/ApiMethods.ts
@@ -78,6 +78,7 @@ const ALL_METHODS = [
   'oauth.token.issued.authorization_code',
   'oauth.token.issued.client_credentials',
   'oauth.token.refreshed',
+  'oauth.token.reuse_detected',
   'oauth.token.revoked'
 ];
 

--- a/components/oauth2/src/audit.ts
+++ b/components/oauth2/src/audit.ts
@@ -49,6 +49,7 @@ export type OAuthAuditEvent =
   | 'oauth.token.issued.authorization_code'
   | 'oauth.token.issued.client_credentials'
   | 'oauth.token.refreshed'
+  | 'oauth.token.reuse_detected'
   | 'oauth.token.revoked';
 
 /**

--- a/components/oauth2/src/grants/refresh_token.ts
+++ b/components/oauth2/src/grants/refresh_token.ts
@@ -11,8 +11,11 @@
  * Exchange flow:
  *   1. Load the refresh row (key: `oauth-refresh/<coreId>/<token>`).
  *      `getAccessState` lazy-expires past `min(expiresAt, absoluteExpiresAt)`.
- *   2. Delete the row atomically (single-use; rotation always on; reuse
- *      → `invalid_grant` + `oauth.refresh.reused` audit signal).
+ *   2. Consume the row atomically (single-use; rotation always on). If the
+ *      token no longer resolves, a consumed-marker lookup distinguishes genuine
+ *      reuse (→ `oauth.token.reuse_detected` + chain revoke past the grace
+ *      window) from expired/never-issued (→ `oauth.code.reused`). Both return
+ *      an identical `invalid_grant` so the two are not distinguishable on the wire.
  *   3. Verify `client_id` matches the row's clientId.
  *   4. Mint a NEW app access under the same user/scope/client via the
  *      injected `mintRefreshedAccess` callback. The grant runs without
@@ -74,10 +77,26 @@ export type MintRefreshedAccess = (params: {
   permissions?: Array<Record<string, unknown>>;
 }) => Promise<{ accessId: string; accessToken: string; apiEndpoint: string }>;
 
+/**
+ * Collapse a refresh chain on detected reuse: soft-delete the durable data-grant
+ * (kills future refreshes) + all live session accesses for (user, client), and
+ * best-effort notify the counterparty app. Storage-direct — wired in the
+ * api-server layer where the accesses repository + cache live. Errors are the
+ * caller's to swallow (a revoke failure must not turn the reuse response into a 500).
+ */
+export type RevokeChain = (params: {
+  userId: string;
+  username: string;
+  clientId: string;
+  dataGrantAccessId?: string;
+}) => Promise<void>;
+
 export type RefreshTokenDeps = {
   config: { get (key: string): unknown };
   platform: PlatformDB;
   mintRefreshedAccess: MintRefreshedAccess;
+  /** Optional: absent → reuse is detected + audited but the chain is not revoked. */
+  revokeChain?: RevokeChain;
 };
 
 export type RefreshGrantParams = {
@@ -122,12 +141,57 @@ export async function handleRefreshToken (
   // two concurrent refreshes of the same token cannot both mint a new chain
   // (which also defeated reuse-detection, since both reads saw the row).
   const row = await storage.consumeRefresh(deps.platform, coreId, params.refresh_token);
+  // Uniform failure description for BOTH the never-existed and the reuse branch —
+  // a distinct message would let an unauthenticated caller probe whether a token
+  // was real + recently consumed (and tell an attacker their theft was detected).
+  const INVALID = { ok: false as const, status: 400, error: 'invalid_grant', description: 'refresh_token is invalid or already used' };
   if (row == null) {
-    // Either expired/never-issued OR already-rotated. Audit as reuse
-    // since the legitimate path always deletes-then-reissues; we can't
-    // distinguish locally, but the security-relevant case is reuse.
-    await audit('oauth.code.reused', { clientId: params.client_id, codeId: 'refresh:' + params.refresh_token.slice(0, 6) + '…' });
-    return { ok: false, status: 400, error: 'invalid_grant', description: 'refresh_token is invalid or already used' };
+    // Token no longer resolves. Consult the consumed marker to tell genuine REUSE
+    // (a rotated token replayed) from expired/never-issued.
+    const marker = await storage.getRefreshConsumed(deps.platform, coreId, params.refresh_token);
+    if (marker == null) {
+      // Expired or never issued — not reuse. Keep the user-less probe signal.
+      await audit('oauth.code.reused', { clientId: params.client_id, codeId: 'refresh:' + params.refresh_token.slice(0, 6) + '…' });
+      return INVALID;
+    }
+    const graceMs = 1000 * Number(deps.config.get('oauth:refreshReuseGraceSeconds') ?? 10);
+    const withinGrace = (Date.now() - marker.consumedAt) < graceMs;
+    await audit('oauth.token.reuse_detected', {
+      clientId: marker.clientId,
+      userId: marker.userId,
+      ...(marker.dataGrantAccessId != null ? { dataGrantAccessId: marker.dataGrantAccessId } : {}),
+      codeId: 'refresh:' + params.refresh_token.slice(0, 6) + '…',
+      reason: withinGrace ? 'within-grace' : 'chain-revoked',
+    });
+    if (!withinGrace && typeof deps.revokeChain === 'function') {
+      try {
+        await deps.revokeChain({
+          userId: marker.userId,
+          username: marker.username,
+          clientId: marker.clientId,
+          ...(marker.dataGrantAccessId != null ? { dataGrantAccessId: marker.dataGrantAccessId } : {}),
+        });
+      } catch (err: unknown) {
+        logServerError('refresh_token: revokeChain failed after reuse detection', err);
+      }
+    }
+    return INVALID; // never 500 on the reuse path — the audit row carries the signal
+  }
+
+  // Mark the just-consumed token so a later replay is detectable as reuse. TTL =
+  // the sooner of the row's sliding + absolute expiry (past that, a replay is
+  // genuinely expired). Best-effort: a lost marker costs one detection, not the
+  // rotation (which already happened atomically above).
+  try {
+    await storage.markRefreshConsumed(deps.platform, coreId, params.refresh_token, {
+      clientId: row.clientId,
+      userId: row.userId,
+      username: row.username,
+      ...(row.dataGrantAccessId != null ? { dataGrantAccessId: row.dataGrantAccessId } : {}),
+      consumedAt: Date.now(),
+    }, Math.min(row.expiresAt, row.absoluteExpiresAt));
+  } catch (err: unknown) {
+    logServerError('refresh_token: markRefreshConsumed failed (reuse detection degraded for this token)', err);
   }
 
   if (params.client_id !== row.clientId) {

--- a/components/oauth2/src/routes.ts
+++ b/components/oauth2/src/routes.ts
@@ -81,6 +81,15 @@ export type Deps = {
   }) => Promise<{ accessId: string; accessToken: string; apiEndpoint: string }>;
   /** Resolve the App account's username to its userId. Required for client_credentials. */
   resolveAccountUserId?: (username: string) => Promise<string | null>;
+  /**
+   * Collapse a refresh chain on detected reuse (refresh_token grant). Storage-
+   * layer-direct: soft-deletes the durable data-grant + all live session accesses
+   * for (user, client) and notifies the counterparty. If absent, reuse is still
+   * detected + audited but the chain is not revoked.
+   */
+  revokeChain?: (params: {
+    userId: string; username: string; clientId: string; dataGrantAccessId?: string;
+  }) => Promise<void>;
 };
 
 /**
@@ -144,6 +153,7 @@ export function registerRoutes (app: { get?: Function; post?: Function; options?
       mintRefreshedAccess: deps.mintRefreshedAccess,
       mintClientAccess: deps.mintClientAccess,
       resolveAccountUserId: deps.resolveAccountUserId,
+      revokeChain: deps.revokeChain,
     }));
 }
 

--- a/components/oauth2/src/routes/token.ts
+++ b/components/oauth2/src/routes/token.ts
@@ -37,6 +37,10 @@ export type TokenDeps = {
   }) => Promise<{ accessId: string; accessToken: string; apiEndpoint: string }>;
   /** Required when grant_type=client_credentials is dispatched. */
   resolveAccountUserId?: (username: string) => Promise<string | null>;
+  /** Optional: collapse a refresh chain on detected reuse (refresh_token grant). */
+  revokeChain?: (params: {
+    userId: string; username: string; clientId: string; dataGrantAccessId?: string;
+  }) => Promise<void>;
 };
 
 /**
@@ -90,7 +94,12 @@ export function handleToken (deps: TokenDeps) {
         outcome = { ok: false, status: 500, error: 'server_error', description: 'refresh_token grant is advertised but not wired on this deployment' };
       } else {
         outcome = await handleRefreshToken(
-          { config: deps.config, platform: deps.platform, mintRefreshedAccess: deps.mintRefreshedAccess },
+          {
+            config: deps.config,
+            platform: deps.platform,
+            mintRefreshedAccess: deps.mintRefreshedAccess,
+            ...(deps.revokeChain != null ? { revokeChain: deps.revokeChain } : {}),
+          },
           { ...body, basic },
         );
       }

--- a/components/oauth2/src/storage.ts
+++ b/components/oauth2/src/storage.ts
@@ -129,9 +129,26 @@ export interface OAuthRefresh {
   permissions?: GrantPermission[];
 }
 
+/**
+ * "Consumed marker" — a short-lived shadow of a refresh row written the moment
+ * it is rotated. Its presence when a token no longer resolves distinguishes
+ * genuine REUSE (a rotated token replayed) from expired/never-issued. Carries
+ * only what reuse-detection needs to revoke the chain — NO live credentials.
+ * TTL matches the consumed row's remaining validity (bounded growth, swept by
+ * sweepExpiredAccessStates). Cluster-wide storage, per-issuing-core key.
+ */
+export interface OAuthRefreshUsed {
+  clientId: string;
+  userId: string;
+  username: string;
+  dataGrantAccessId?: string;
+  consumedAt: number; // Date.now() at rotation — drives the grace window
+}
+
 const PREFIX_CLIENT = 'oauth-client/';
 const PREFIX_CODE = 'oauth-code/';
 const PREFIX_REFRESH = 'oauth-refresh/';
+const PREFIX_REFRESH_USED = 'oauth-refresh-used/';
 
 // --- Client metadata (indefinite, cluster-wide) --- //
 
@@ -236,6 +253,26 @@ export async function consumeRefresh (platform: PlatformDB, coreId: string, toke
   return entry == null ? null : (entry.value as OAuthRefresh);
 }
 
+// --- Reuse-detection consumed marker (short-lived shadow of a rotated refresh) --- //
+
+/**
+ * Record that a refresh token was just consumed (rotated). `expiresAt` should be
+ * the SOONER of the consumed row's sliding + absolute expiry, so the marker lives
+ * exactly as long as the token would have remained valid — past that, a replay is
+ * indistinguishable from expired and correctly classified as such.
+ */
+export async function markRefreshConsumed (
+  platform: PlatformDB, coreId: string, token: string, payload: OAuthRefreshUsed, expiresAt: number,
+): Promise<void> {
+  await platform.setAccessState(refreshUsedKey(coreId, token), payload, expiresAt);
+}
+
+/** Non-consuming read of the consumed marker (repeat replays must each re-detect). */
+export async function getRefreshConsumed (platform: PlatformDB, coreId: string, token: string): Promise<OAuthRefreshUsed | null> {
+  const entry = await platform.getAccessState(refreshUsedKey(coreId, token));
+  return entry == null ? null : (entry.value as OAuthRefreshUsed);
+}
+
 // --- Key helpers (owned here, NOT in the engine) --- //
 
 function codeKey (code: string): string {
@@ -244,4 +281,8 @@ function codeKey (code: string): string {
 
 function refreshKey (coreId: string, token: string): string {
   return PREFIX_REFRESH + coreId + '/' + token;
+}
+
+function refreshUsedKey (coreId: string, token: string): string {
+  return PREFIX_REFRESH_USED + coreId + '/' + token;
 }

--- a/components/oauth2/test/audit.test.js
+++ b/components/oauth2/test/audit.test.js
@@ -31,6 +31,7 @@ const OAUTH_EVENTS = [
   'oauth.token.issued.authorization_code',
   'oauth.token.issued.client_credentials',
   'oauth.token.refreshed',
+  'oauth.token.reuse_detected',
   'oauth.token.revoked'
 ];
 

--- a/components/oauth2/test/refresh_token.test.js
+++ b/components/oauth2/test/refresh_token.test.js
@@ -17,7 +17,7 @@ const require = createRequire(import.meta.url);
 
 const assert = require('node:assert/strict');
 const { handleToken } = require('../src/routes/token.ts');
-const { setRefresh, getRefresh } = require('../src/storage.ts');
+const { setRefresh, getRefresh, getRefreshConsumed } = require('../src/storage.ts');
 
 const ISSUER = 'https://reg.pryv.me';
 const CORE_ID = 'core-a';
@@ -319,6 +319,151 @@ describe('[OAUTH-TKN-RT] /oauth2/token — refresh_token grant', () => {
       const res = fakeRes();
       await handler({ body: { grant_type: 'refresh_token', refresh_token: 'RT-CF4', client_id: 'myapp' } }, res);
       assert.equal(res.statusCode, 200);
+    });
+  });
+
+  describe('[OAUTH-TKN-RT-REUSEDET] reuse-detection enforcement (chain revoke)', () => {
+    // grace override; 0 = strict (any post-rotation replay revokes)
+    function withRevoke (platform, grace, calls) {
+      return handleToken({
+        config: fakeConfig({ 'oauth:refreshReuseGraceSeconds': grace }),
+        platform,
+        mintRefreshedAccess: MINT_REFRESHED_FAKE,
+        revokeChain: async (p) => { calls.push(p); },
+      });
+    }
+
+    it('[OTR-RD1] reuse past grace → revokeChain fires with the chain identity from the marker', async () => {
+      const platform = fakePlatform();
+      await seedRefresh(platform, 'RT-RD1', { dataGrantAccessId: 'dg-rd1' });
+      const calls = [];
+      const handler = withRevoke(platform, 0, calls);
+      const params = { grant_type: 'refresh_token', refresh_token: 'RT-RD1', client_id: 'myapp' };
+      const r1 = fakeRes(); await handler({ body: params }, r1);
+      assert.equal(r1.statusCode, 200);
+      const r2 = fakeRes(); await handler({ body: params }, r2);
+      assert.equal(r2.statusCode, 400);
+      assert.equal(r2.body.error, 'invalid_grant');
+      assert.equal(calls.length, 1, 'revokeChain must fire on reuse past grace');
+      assert.deepEqual(calls[0], { userId: 'u-alice', username: 'alice', clientId: 'myapp', dataGrantAccessId: 'dg-rd1' });
+    });
+
+    it('[OTR-RD2] double-submit within grace → NO revoke (benign)', async () => {
+      const platform = fakePlatform();
+      await seedRefresh(platform, 'RT-RD2', { dataGrantAccessId: 'dg-rd2' });
+      const calls = [];
+      const handler = withRevoke(platform, 60, calls);
+      const params = { grant_type: 'refresh_token', refresh_token: 'RT-RD2', client_id: 'myapp' };
+      const r1 = fakeRes(); await handler({ body: params }, r1);
+      assert.equal(r1.statusCode, 200);
+      const r2 = fakeRes(); await handler({ body: params }, r2);
+      assert.equal(r2.statusCode, 400);
+      assert.equal(calls.length, 0, 'within grace = benign double-submit, chain preserved');
+    });
+
+    it('[OTR-RD3] never-issued token → NOT reuse, no revoke', async () => {
+      const platform = fakePlatform();
+      const calls = [];
+      const handler = withRevoke(platform, 0, calls);
+      const res = fakeRes();
+      await handler({ body: { grant_type: 'refresh_token', refresh_token: 'NEVER', client_id: 'myapp' } }, res);
+      assert.equal(res.statusCode, 400);
+      assert.equal(calls.length, 0);
+    });
+
+    it('[OTR-RD4] marker gone (TTL expired) → classified expired, no revoke', async () => {
+      const platform = fakePlatform();
+      await seedRefresh(platform, 'RT-RD4', { dataGrantAccessId: 'dg-rd4' });
+      const calls = [];
+      const handler = withRevoke(platform, 0, calls);
+      const params = { grant_type: 'refresh_token', refresh_token: 'RT-RD4', client_id: 'myapp' };
+      await handler({ body: params }, fakeRes());
+      platform._state.delete('oauth-refresh-used/' + CORE_ID + '/RT-RD4'); // simulate marker TTL expiry
+      const r2 = fakeRes(); await handler({ body: params }, r2);
+      assert.equal(r2.statusCode, 400);
+      assert.equal(calls.length, 0, 'no marker → treated as expired, not reuse');
+    });
+
+    it('[OTR-RD5] consumed marker carries chain identity + consumedAt, NO live token, TTL = min(exp, absExp)', async () => {
+      const platform = fakePlatform();
+      const exp = Date.now() + 5 * 24 * 3600 * 1000;      // sooner
+      const absExp = Date.now() + 90 * 24 * 3600 * 1000;  // later
+      await seedRefresh(platform, 'RT-RD5', { dataGrantAccessId: 'dg-rd5', expiresAt: exp, absoluteExpiresAt: absExp });
+      const handler = handleToken({ config: fakeConfig(), platform, mintRefreshedAccess: MINT_REFRESHED_FAKE });
+      await handler({ body: { grant_type: 'refresh_token', refresh_token: 'RT-RD5', client_id: 'myapp' } }, fakeRes());
+      const marker = await getRefreshConsumed(platform, CORE_ID, 'RT-RD5');
+      assert.ok(marker != null);
+      assert.equal(marker.userId, 'u-alice');
+      assert.equal(marker.clientId, 'myapp');
+      assert.equal(marker.dataGrantAccessId, 'dg-rd5');
+      assert.equal(typeof marker.consumedAt, 'number');
+      assert.ok(!JSON.stringify(marker).includes('RT-RD5'), 'marker must not carry the token string');
+      // Marker TTL = min(expiresAt, absoluteExpiresAt) of the consumed row.
+      const entry = platform._state.get('oauth-refresh-used/' + CORE_ID + '/RT-RD5');
+      assert.equal(entry.expiresAt, exp, 'marker TTL must be the sooner of the row expiry / absolute cap');
+    });
+
+    it('[OTR-RD6] marker write failure is non-fatal (rotation still succeeds)', async () => {
+      const platform = fakePlatform();
+      await seedRefresh(platform, 'RT-RD6');
+      const origSet = platform.setAccessState.bind(platform);
+      platform.setAccessState = async (k, v, e) => {
+        if (k.startsWith('oauth-refresh-used/')) throw new Error('marker write boom');
+        return origSet(k, v, e);
+      };
+      const handler = handleToken({ config: fakeConfig(), platform, mintRefreshedAccess: MINT_REFRESHED_FAKE });
+      const res = fakeRes();
+      await handler({ body: { grant_type: 'refresh_token', refresh_token: 'RT-RD6', client_id: 'myapp' } }, res);
+      assert.equal(res.statusCode, 200, 'a marker write failure must not fail the rotation');
+    });
+
+    it('[OTR-RD7] revokeChain throwing → still invalid_grant, never 500', async () => {
+      const platform = fakePlatform();
+      await seedRefresh(platform, 'RT-RD7', { dataGrantAccessId: 'dg-rd7' });
+      const handler = handleToken({
+        config: fakeConfig({ 'oauth:refreshReuseGraceSeconds': 0 }),
+        platform,
+        mintRefreshedAccess: MINT_REFRESHED_FAKE,
+        revokeChain: async () => { throw new Error('revoke boom'); },
+      });
+      const params = { grant_type: 'refresh_token', refresh_token: 'RT-RD7', client_id: 'myapp' };
+      await handler({ body: params }, fakeRes());
+      const r2 = fakeRes(); await handler({ body: params }, r2);
+      assert.equal(r2.statusCode, 400);
+      assert.equal(r2.body.error, 'invalid_grant');
+    });
+
+    it('[OTR-RD8] repeat replay → revokeChain fires each time (marker persists, non-consuming)', async () => {
+      const platform = fakePlatform();
+      await seedRefresh(platform, 'RT-RD8', { dataGrantAccessId: 'dg-rd8' });
+      const calls = [];
+      const handler = withRevoke(platform, 0, calls);
+      const params = { grant_type: 'refresh_token', refresh_token: 'RT-RD8', client_id: 'myapp' };
+      await handler({ body: params }, fakeRes()); // rotate
+      await handler({ body: params }, fakeRes()); // replay 1
+      await handler({ body: params }, fakeRes()); // replay 2
+      assert.equal(calls.length, 2, 'each post-grace replay must re-detect + revoke');
+    });
+
+    it('[OTR-RD9] revokeChain absent → detect + audit only, no throw (400)', async () => {
+      const platform = fakePlatform();
+      await seedRefresh(platform, 'RT-RD9', { dataGrantAccessId: 'dg-rd9' });
+      const handler = handleToken({ config: fakeConfig({ 'oauth:refreshReuseGraceSeconds': 0 }), platform, mintRefreshedAccess: MINT_REFRESHED_FAKE });
+      const params = { grant_type: 'refresh_token', refresh_token: 'RT-RD9', client_id: 'myapp' };
+      await handler({ body: params }, fakeRes());
+      const r2 = fakeRes(); await handler({ body: params }, r2);
+      assert.equal(r2.statusCode, 400);
+      assert.equal(r2.body.error, 'invalid_grant');
+    });
+
+    it('[OTR-RD10] reuse and never-issued return the SAME error_description (no oracle)', async () => {
+      const platform = fakePlatform();
+      await seedRefresh(platform, 'RT-RD10', { dataGrantAccessId: 'dg-rd10' });
+      const handler = handleToken({ config: fakeConfig({ 'oauth:refreshReuseGraceSeconds': 0 }), platform, mintRefreshedAccess: MINT_REFRESHED_FAKE, revokeChain: async () => {} });
+      await handler({ body: { grant_type: 'refresh_token', refresh_token: 'RT-RD10', client_id: 'myapp' } }, fakeRes());
+      const reuse = fakeRes(); await handler({ body: { grant_type: 'refresh_token', refresh_token: 'RT-RD10', client_id: 'myapp' } }, reuse);
+      const miss = fakeRes(); await handler({ body: { grant_type: 'refresh_token', refresh_token: 'NEVER-X', client_id: 'myapp' } }, miss);
+      assert.equal(reuse.body.error_description, miss.body.error_description, 'reuse must not be distinguishable from never-issued');
     });
   });
 });

--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -525,6 +525,11 @@ oauth:
   accessTokenTTL: 3600             # seconds (1 hour default)
   refreshTokenTTL: 2592000         # seconds (30 days sliding)
   refreshTokenAbsoluteTTL: 7776000 # seconds (90 days absolute cap)
+  # Refresh-token reuse detection: replaying an already-rotated token within this
+  # window of its rotation is treated as a benign double-submit (no chain revoke);
+  # a replay past it revokes the whole chain. Keep small — real client retries are
+  # sub-second. 0 = strict (any replay revokes).
+  refreshReuseGraceSeconds: 10     # seconds
   clientRegistration:
     mode: curated                  # ONLY supported value; "open" is rejected
   requireAppAccountMfa: true       # app accounts must enrol MFA before /oauth2/* writes


### PR DESCRIPTION
Stacked on #110 (merge that first; this PR then reduces to its single commit).

## What

Detects reuse of an already-rotated refresh token and revokes the whole token
chain, per the OAuth 2.0 Security BCP (RFC 9700 §4.14.2).

- On each successful refresh rotation, a consumed-marker is written to the
  platform KV (`oauth-refresh-used/<coreId>/<token>`, TTL = the rotated
  token's remaining lifetime, no credentials stored).
- A refresh attempt with an unknown token checks the marker: a hit outside the
  grace window means the token was already consumed — a replay. The response is
  the same `invalid_grant` as for a never-issued token (no oracle), an
  `oauth.token.reuse_detected` audit event is emitted, and the chain is revoked.
- Grace window for benign double-submits (network retry racing the rotation):
  `oauth:refreshReuseGraceSeconds`, default 10, `0` = strict.

## Chain revocation

`revokeChain` (api-server seam injected into the oauth2 component) soft-deletes
the data-grant head access, the client's app sessions (`oauth:<clientId>`), and
their descendants; cascades webhook deletion; invalidates the access cache
cluster-wide; and notifies the CMC counterparty via the stored peer apiEndpoint
(best-effort, mirroring the accesses.delete post-hook semantics — storage-direct
deletes don't pass through the route chain, so the notify is explicit here).
Blast radius is per (user, client): other users/clients of the same offer are
untouched. `revokeChain` failures still return `invalid_grant` (fail closed for
the caller) and are logged.

## Known limitation

Re-consenting to an open-link consent offer after any revocation currently
fails on the requester side (the capability's accepted-by bookkeeping is not
cleared on revoke — pre-existing, affects every revocation path, tracked
separately). An isolated end-to-end reuse→revoke test will follow once that is
fixed.

## Validation

- oauth2 unit 280 (10 new reuse-detection tests: replay→revoke, grace window,
  never-issued, expired marker, marker TTL/fields, marker-write failure
  non-fatal, revokeChain failure handling, repeat replay, seam absent, uniform
  error body) · audit 53 · cmc 445 · OAuth e2e 20 · CMC handshake 19
- Full PostgreSQL matrix 3236 passing / 1 pre-existing MFA-suite flake
  (reproduced on clean master, unrelated) · full SQLite matrix clean
  (3 environmental failures all pass isolated)
- typecheck + all lint gates green
