### PR TITLE
oauth2: DPoP (RFC 9449) sender-constrained tokens

### DIFF
--- a/components/api-server/src/methods/accesses.ts
+++ b/components/api-server/src/methods/accesses.ts
@@ -262,6 +262,7 @@ export default async function produceAccessesApiMethods (api: { register (...arg
     applyDefaultsForCreation,
     commonFns.getParamsValidation(methodsSchema.create.params),
     cmcAccessCreateForgePreventionHook,
+    dpopBindingCreateGuard,
     applyPrerequisitesForCreation, applyAccountStreamsValidation,
     createDataStructureFromPermissions,
     cleanupPermissions,
@@ -272,6 +273,21 @@ export default async function produceAccessesApiMethods (api: { register (...arg
 
   function applyDefaultsForCreation (context: MethodContext, params: AccessesCreateParams, result: AccessesCreateResult, next: MethodNext) {
     params.type ??= 'shared';
+    next();
+  }
+
+  /**
+   * The DPoP key binding (`clientData.dpop`) is written ONLY by the OAuth
+   * token-issuance path (storage-direct, not this method). Rejecting it
+   * here keeps the resource-server's sender-constraint check authoritative
+   * — a caller cannot mint a self-bound access out of band — and mirrors
+   * the update-path anti-downgrade guard.
+   */
+  function dpopBindingCreateGuard (context: MethodContext, params: AccessesCreateParams, result: AccessesCreateResult, next: MethodNext) {
+    const cd = params.clientData as Record<string, unknown> | null | undefined;
+    if (cd != null && cd.dpop !== undefined) {
+      return next(errors.forbidden('clientData.dpop is reserved for the OAuth token-issuance path and cannot be set through accesses.create.'));
+    }
     next();
   }
 

--- a/components/api-server/src/methods/accesses.ts
+++ b/components/api-server/src/methods/accesses.ts
@@ -496,6 +496,7 @@ export default async function produceAccessesApiMethods (api: { register (...arg
     commonFns.getParamsValidation(methodsSchema.update.params),
     cmcAccessUpdateForgePreventionHook,
     loadAccessForUpdate,
+    dpopBindingUpdateGuard,
     enforceUpdateChainRules,
     cleanupUpdatePermissions,
     snapshotAndApplyUpdate,
@@ -578,6 +579,27 @@ export default async function produceAccessesApiMethods (api: { register (...arg
     }
     params.targetAccess = access as AccessLike;
     params.targetBase = ref.base;
+    next();
+  }
+
+  /**
+   * A DPoP key binding (`clientData.dpop`) is written only by the token
+   * issuance path and must survive every accesses.update — the update
+   * replaces `clientData` WHOLESALE, so without this guard any caller
+   * able to update the access could send a dpop-free clientData and
+   * silently downgrade a sender-constrained token to Bearer. Rule: when
+   * the update touches clientData, the binding (present or absent) must
+   * come through unchanged. Defense-in-depth: with uniform enforcement
+   * a stolen bound token cannot reach this method in the first place.
+   */
+  function dpopBindingUpdateGuard (context: MethodContext, params: AccessesUpdateParams, result: AccessesUpdateResult, next: MethodNext) {
+    const updatedClientData = params.update?.clientData as Record<string, unknown> | null | undefined;
+    if (updatedClientData === undefined) return next(); // clientData untouched
+    const currentDpop = (params.targetAccess as { clientData?: { dpop?: unknown } })?.clientData?.dpop;
+    const updatedDpop = updatedClientData == null ? undefined : updatedClientData.dpop;
+    if (JSON.stringify(currentDpop ?? null) !== JSON.stringify(updatedDpop ?? null)) {
+      return next(errors.forbidden('The clientData.dpop key binding cannot be created, changed or removed through accesses.update.'));
+    }
     next();
   }
 

--- a/components/api-server/src/middleware/errors.ts
+++ b/components/api-server/src/middleware/errors.ts
@@ -44,6 +44,12 @@ function produceHandleErrorMiddleware (logging: { getLogger: (name: string) => u
       // req.context.tracing.finishSpan('express1');
     }
     errorHandling.logError(error, req, logger);
+    // Error-scoped response headers (e.g. WWW-Authenticate challenges
+    // for auth-scheme failures) ride on the error object itself.
+    const errorHeaders = (error as { httpHeaders?: Record<string, string> }).httpHeaders;
+    if (errorHeaders != null) {
+      for (const [name, value] of Object.entries(errorHeaders)) res.setHeader(name, value);
+    }
     res
       .status(error.httpStatus || 500)
       .json(commonMeta.setCommonMeta({

--- a/components/api-server/src/routes/events.ts
+++ b/components/api-server/src/routes/events.ts
@@ -85,6 +85,10 @@ export default async function (expressApp: ExpressApp, app: AppLike) {
       .then((access: { token: string }) => {
         const hmacValid = encryption.isFileReadTokenHMACValid(tokenParts.hmac, req.params.fileId, access.token, filesReadTokenSecret);
         if (!hmacValid) { return next(errors.invalidAccessToken('Invalid read token.')); }
+        // The HMAC is the possession proof for this single-file read, so
+        // a DPoP-bound access reaches its attachments here without a DPoP
+        // header (a download / <img src> GET cannot carry one).
+        context.readTokenAuthenticated = true;
         next();
       })
       .catch((err: Error) => next(errors.unexpectedError(err)));

--- a/components/api-server/src/routes/oauth2.ts
+++ b/components/api-server/src/routes/oauth2.ts
@@ -494,9 +494,13 @@ export default function mountOAuth2 (expressApp: ExpressApp, app: AppLike): void
     const existingClientData: Record<string, unknown> = (access.clientData != null && typeof access.clientData === 'object')
       ? { ...access.clientData }
       : {};
+    // Pass `modified` so the integrity-aware updateOne recomputes the
+    // tamper-evidence hash over the post-update row itself (it skips the
+    // recompute when `modified` is absent) — hand-computing the hash here
+    // would have to replicate the storage layer's canonicalization.
     await fromCallback((cb: (e: unknown) => void) =>
       accessesRepository.updateOne(user, { id: accessId },
-        { clientData: { ...existingClientData, dpop: { jkt } } }, cb));
+        { clientData: { ...existingClientData, dpop: { jkt } }, modified: Math.floor(Date.now() / 1000) }, cb));
     cache.unsetUserData(userId);
     pubsub.notifications.emit(username, pubsub.USERNAME_BASED_ACCESSES_CHANGED);
   }

--- a/components/api-server/src/routes/oauth2.ts
+++ b/components/api-server/src/routes/oauth2.ts
@@ -103,6 +103,7 @@ type AccessesRepo = {
   find: (user: { id: string; username: string }, query: Record<string, unknown>, opts: unknown, cb: (err: unknown, found: DataGrant[] | null) => void) => void;
   delete: (user: { id: string; username: string }, query: Record<string, unknown>, cb: (err: unknown) => void) => void;
   insertOne: (user: { id: string; username: string }, row: Record<string, unknown>, cb: (err: unknown, created: { id?: unknown; token?: unknown } | null) => void) => void;
+  updateOne: (user: { id: string; username: string }, query: Record<string, unknown>, update: Record<string, unknown>, cb: (err: unknown) => void) => void;
   generateToken: () => string;
 };
 
@@ -383,9 +384,10 @@ export default function mountOAuth2 (expressApp: ExpressApp, app: AppLike): void
     return head;
   }
 
-  async function mintAccessDirect ({ userId, username, clientId, permissions, expiresAt }: {
+  async function mintAccessDirect ({ userId, username, clientId, permissions, expiresAt, dpopJkt }: {
     userId: string; username: string; clientId: string;
     permissions: Array<Record<string, unknown>>; expiresAt: number;
+    dpopJkt?: string;
   }): Promise<{ accessId: string; accessToken: string; apiEndpoint: string }> {
     if (typeof username !== 'string' || username.length === 0) {
       throw new Error('mintAccessDirect: username required');
@@ -407,6 +409,9 @@ export default function mountOAuth2 (expressApp: ExpressApp, app: AppLike): void
       modified: now,
       modifiedBy: 'system',
       expires: Math.floor(expiresAt / 1000),
+      // Sender-constrained sessions carry the key thumbprint the
+      // resource layer checks the per-request proof against.
+      ...(dpopJkt != null ? { clientData: { dpop: { jkt: dpopJkt } } } : {}),
     };
     const ApiEndpoint = require('utils').ApiEndpoint;
     return await new Promise((resolve, reject) => {
@@ -446,10 +451,11 @@ export default function mountOAuth2 (expressApp: ExpressApp, app: AppLike): void
   //     minted access manages the app's OWN per-user storage (cmc
   //     scopes are rejected upstream by the grant).
   // ---------------------------------------------------------------------
-  async function mintRefreshedAccess ({ userId, username, clientId, expiresAt, dataGrantAccessId, permissions }: {
+  async function mintRefreshedAccess ({ userId, username, clientId, expiresAt, dataGrantAccessId, permissions, jkt }: {
     userId: string; username: string; clientId: string; scope: string[]; expiresAt: number;
     dataGrantAccessId?: string;
     permissions?: Array<Record<string, unknown>>;
+    jkt?: string;
   }): Promise<{ accessId: string; accessToken: string; apiEndpoint: string }> {
     if (dataGrantAccessId == null || !Array.isArray(permissions) || permissions.length === 0) {
       const revoked = new Error('refresh chain carries no consent data-grant binding') as Error & { code: string };
@@ -466,7 +472,33 @@ export default function mountOAuth2 (expressApp: ExpressApp, app: AppLike): void
       revoked.code = 'data-grant-revoked';
       throw revoked;
     }
-    return mintAccessDirect({ userId, username, clientId, permissions: effective, expiresAt });
+    return mintAccessDirect({ userId, username, clientId, permissions: effective, expiresAt, ...(jkt != null ? { dpopJkt: jkt } : {}) });
+  }
+
+  // ---------------------------------------------------------------------
+  // bindAccessDpop — stamp the DPoP key thumbprint onto the access that
+  // was pre-minted at /authorize/accept (the proof only appears at
+  // /token). Storage-direct read-merge-update so other clientData
+  // survives, then cluster-wide cache invalidation: the resource layer
+  // must see the binding on the very next request.
+  // ---------------------------------------------------------------------
+  async function bindAccessDpop ({ userId, username, accessId, jkt }: {
+    userId: string; username: string; accessId: string; jkt: string;
+  }): Promise<void> {
+    const accessesRepository = (storageLayer as { accesses?: AccessesRepo }).accesses;
+    if (accessesRepository == null) throw new Error('oauth2.bindAccessDpop: storageLayer.accesses unavailable');
+    const user = { id: userId, username };
+    const access = await fromCallback((cb: (e: unknown, r: DataGrant | null) => void) =>
+      accessesRepository.findOne(user, { id: accessId }, null, cb));
+    if (access == null) throw new Error('oauth2.bindAccessDpop: access not found: ' + accessId);
+    const existingClientData: Record<string, unknown> = (access.clientData != null && typeof access.clientData === 'object')
+      ? { ...access.clientData }
+      : {};
+    await fromCallback((cb: (e: unknown) => void) =>
+      accessesRepository.updateOne(user, { id: accessId },
+        { clientData: { ...existingClientData, dpop: { jkt } } }, cb));
+    cache.unsetUserData(userId);
+    pubsub.notifications.emit(username, pubsub.USERNAME_BASED_ACCESSES_CHANGED);
   }
 
   async function mintClientAccess ({ userId, username, clientId, expiresAt }: {
@@ -606,6 +638,7 @@ export default function mountOAuth2 (expressApp: ExpressApp, app: AppLike): void
     mintClientAccess,
     resolveAccountUserId,
     revokeChain,
+    bindAccessDpop,
     resolveUser,
     createAccess,
   });

--- a/components/api-server/test/dpop-enforcement.test.js
+++ b/components/api-server/test/dpop-enforcement.test.js
@@ -198,4 +198,65 @@ describe('[DPOP-RS] DPoP sender-constraint enforcement on the resource server', 
       .send({ clientData: { note: 'plain' } });
     assert.equal(ok.status, 200, JSON.stringify(ok.body));
   });
+
+  it('[DPN11] accesses.create rejects a client-supplied clientData.dpop binding', async function () {
+    const res = await coreRequest
+      .post(`/${username}/accesses`)
+      .set('Authorization', personalToken)
+      .send({
+        type: 'app',
+        name: 'self-bound-attempt',
+        permissions: [{ streamId: 'health', level: 'read' }],
+        clientData: { dpop: { jkt: 'self-chosen-thumbprint' } },
+      });
+    assert.equal(res.status, 403, JSON.stringify(res.body));
+    // The same create WITHOUT the reserved key succeeds.
+    const ok = await coreRequest
+      .post(`/${username}/accesses`)
+      .set('Authorization', personalToken)
+      .send({
+        type: 'app',
+        name: 'plain-create',
+        permissions: [{ streamId: 'health', level: 'read' }],
+        clientData: { note: 'fine' },
+      });
+    assert.equal(ok.status, 201, JSON.stringify(ok.body));
+  });
+
+  it('[DPN12] a bound access reaches its attachments via readToken WITHOUT a DPoP proof (download/img path), but general API calls still need one', async function () {
+    // personalToken owns the data; create an event with an attachment in
+    // the stream the bound access can read.
+    const created = await coreRequest
+      .post(`/${username}/events`)
+      .set('Authorization', personalToken)
+      .field('event', JSON.stringify({ streamIds: ['health'], type: 'note/txt', content: 'x' }))
+      .attach('file', Buffer.from('hello-attachment'), 'a.txt');
+    assert.equal(created.status, 201, JSON.stringify(created.body));
+
+    // The bound access lists the event WITH a proof — the response carries
+    // a readToken computed for the bound access.
+    const list = await fwd(coreRequest.get(`/${username}/events`).query({ streams: ['health'] }))
+      .set('Authorization', 'DPoP ' + boundToken)
+      .set('DPoP', await makeProof(key, { htm: 'GET', path: `/${username}/events`, accessToken: boundToken }));
+    assert.equal(list.status, 200, dbg(list));
+    const evt = list.body.events.find((e) => (e.attachments ?? []).length > 0);
+    assert.ok(evt != null, 'an event with an attachment is listed: ' + JSON.stringify(list.body.events));
+    const att = evt.attachments[0];
+    assert.ok(typeof att.readToken === 'string', 'attachment carries a readToken: ' + JSON.stringify(att));
+    const attPath = `/${username}/events/${evt.id}/${att.id}`;
+
+    // Download via readToken alone — no Authorization, no DPoP header — works.
+    const dl = await coreRequest.get(attPath).query({ readToken: att.readToken });
+    assert.equal(dl.status, 200, dbg(dl));
+    assert.equal(dl.text, 'hello-attachment');
+
+    // But the same attachment path with the bound token as Bearer and no
+    // proof is still refused — the exemption is readToken-only.
+    const noProof = await coreRequest.get(attPath).set('Authorization', boundToken);
+    assert.equal(noProof.status, 403, dbg(noProof));
+  });
 });
+
+function dbg (res) {
+  return `status=${res.status} body=${JSON.stringify(res.body)} text=${(res.text || '').slice(0, 120)}`;
+}

--- a/components/api-server/test/dpop-enforcement.test.js
+++ b/components/api-server/test/dpop-enforcement.test.js
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright (C) Pryv https://pryv.com
+ * This file is part of Pryv.io and released under BSD-Clause-3 License
+ * Refer to LICENSE file
+ */
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+/**
+ * [DPOP-RS] Resource-server enforcement of DPoP (RFC 9449) key binding.
+ *
+ * An access carrying `clientData.dpop.jkt` must present a valid proof
+ * (right key, right request line, fresh single-use jti, token-bound
+ * ath) on EVERY request; an unbound access must never be usable under
+ * the DPoP scheme; and the binding cannot be stripped via
+ * accesses.update. All refusals are uniform.
+ */
+
+/* global initTests, initCore, coreRequest, getNewFixture, cuid */
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const { webcrypto } = require('node:crypto');
+const { computeJkt } = require('oauth2/src/dpop.ts');
+
+const { subtle } = webcrypto;
+// The client-facing host a DPoP client signs into htu. Delivered via the
+// reverse-proxy forwarding headers (which externalRequestUri prefers),
+// so the server reconstructs THIS host even though supertest's own Host
+// is 127.0.0.1 — and subdomain→path routing, which reads the real Host,
+// never sees it. Exercises the F5 proxy path.
+const HOST = 'api.example.com';
+const fwd = (req) => req.set('X-Forwarded-Host', HOST).set('X-Forwarded-Proto', 'http');
+
+async function makeKeyPair () {
+  const pair = await subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+  const jwk = await subtle.exportKey('jwk', pair.publicKey);
+  return { pair, publicJwk: { kty: jwk.kty, crv: jwk.crv, x: jwk.x, y: jwk.y } };
+}
+
+async function makeProof (key, { htm, path, accessToken, jti }) {
+  const b64url = (buf) => Buffer.from(buf).toString('base64url');
+  const header = { typ: 'dpop+jwt', alg: 'ES256', jwk: key.publicJwk };
+  const payload = {
+    jti: jti ?? 'jti-' + crypto.randomUUID(),
+    htm,
+    htu: `http://${HOST}${path}`,
+    iat: Math.floor(Date.now() / 1000),
+    ...(accessToken != null ? { ath: crypto.createHash('sha256').update(accessToken).digest('base64url') } : {}),
+  };
+  const h = b64url(JSON.stringify(header));
+  const p = b64url(JSON.stringify(payload));
+  const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key.pair.privateKey, Buffer.from(`${h}.${p}`, 'utf8'));
+  return `${h}.${p}.${b64url(sig)}`;
+}
+
+describe('[DPOP-RS] DPoP sender-constraint enforcement on the resource server', function () {
+  this.timeout(40000);
+
+  let fixtures, username, personalToken, boundToken, boundAccessId, unboundToken, unboundAccessId, key;
+
+  before(async function () {
+    await initTests();
+    await initCore();
+    fixtures = getNewFixture();
+    key = await makeKeyPair();
+    username = cuid();
+    personalToken = cuid();
+    boundToken = cuid();
+    unboundToken = cuid();
+    const user = await fixtures.user(username);
+    await user.access({ token: personalToken, type: 'personal' });
+    await user.session(personalToken);
+    await user.stream({ id: 'health', name: 'Health' });
+    const bound = await user.access({
+      type: 'app',
+      token: boundToken,
+      name: 'dpop-bound-app',
+      permissions: [{ streamId: 'health', level: 'read' }],
+      clientData: { dpop: { jkt: computeJkt(key.publicJwk) } },
+    });
+    boundAccessId = bound.attrs.id;
+    const unbound = await user.access({
+      type: 'app',
+      token: unboundToken,
+      name: 'plain-bearer-app',
+      permissions: [{ streamId: 'health', level: 'read' }],
+    });
+    unboundAccessId = unbound.attrs.id;
+  });
+
+  after(async function () {
+    if (fixtures) await fixtures.context.cleanEverything();
+  });
+
+  function accessInfo () {
+    return fwd(coreRequest.get(`/${username}/access-info`));
+  }
+  const path = () => `/${username}/access-info`;
+
+  it('[DPN01] bound access + valid proof under the DPoP scheme succeeds', async function () {
+    const proof = await makeProof(key, { htm: 'GET', path: path(), accessToken: boundToken });
+    const res = await accessInfo().set('Authorization', 'DPoP ' + boundToken).set('DPoP', proof);
+    assert.equal(res.status, 200, JSON.stringify(res.body));
+    assert.equal(res.body.name, 'dpop-bound-app');
+  });
+
+  it('[DPN02] bound access WITHOUT a proof is refused — bare and Bearer alike', async function () {
+    const bare = await accessInfo().set('Authorization', boundToken);
+    assert.equal(bare.status, 403, JSON.stringify(bare.body));
+    const bearer = await accessInfo().set('Authorization', 'Bearer ' + boundToken);
+    assert.equal(bearer.status, 403, JSON.stringify(bearer.body));
+    assert.match(bearer.headers['www-authenticate'] ?? '', /DPoP/);
+  });
+
+  it('[DPN03] a proof for another request line (htm/htu) is refused', async function () {
+    const wrongPath = await makeProof(key, { htm: 'GET', path: `/${username}/events`, accessToken: boundToken });
+    const res = await accessInfo().set('Authorization', 'DPoP ' + boundToken).set('DPoP', wrongPath);
+    assert.equal(res.status, 403);
+    const wrongMethod = await makeProof(key, { htm: 'POST', path: path(), accessToken: boundToken });
+    const res2 = await accessInfo().set('Authorization', 'DPoP ' + boundToken).set('DPoP', wrongMethod);
+    assert.equal(res2.status, 403);
+  });
+
+  it('[DPN04] a proof signed by a DIFFERENT key is refused', async function () {
+    const otherKey = await makeKeyPair();
+    const proof = await makeProof(otherKey, { htm: 'GET', path: path(), accessToken: boundToken });
+    const res = await accessInfo().set('Authorization', 'DPoP ' + boundToken).set('DPoP', proof);
+    assert.equal(res.status, 403);
+  });
+
+  it('[DPN05] a proof missing/mismatching ath is refused', async function () {
+    const noAth = await makeProof(key, { htm: 'GET', path: path() });
+    const res = await accessInfo().set('Authorization', 'DPoP ' + boundToken).set('DPoP', noAth);
+    assert.equal(res.status, 403);
+    const wrongAth = await makeProof(key, { htm: 'GET', path: path(), accessToken: 'some-other-token' });
+    const res2 = await accessInfo().set('Authorization', 'DPoP ' + boundToken).set('DPoP', wrongAth);
+    assert.equal(res2.status, 403);
+  });
+
+  it('[DPN06] jti single-use: replaying a successful proof is refused', async function () {
+    const proof = await makeProof(key, { htm: 'GET', path: path(), accessToken: boundToken });
+    const first = await accessInfo().set('Authorization', 'DPoP ' + boundToken).set('DPoP', proof);
+    assert.equal(first.status, 200, JSON.stringify(first.body));
+    const replay = await accessInfo().set('Authorization', 'DPoP ' + boundToken).set('DPoP', proof);
+    assert.equal(replay.status, 403);
+  });
+
+  it('[DPN07] an UNBOUND access under the DPoP scheme is refused (kind is fixed at issuance)', async function () {
+    const proof = await makeProof(key, { htm: 'GET', path: path(), accessToken: unboundToken });
+    const res = await accessInfo().set('Authorization', 'DPoP ' + unboundToken).set('DPoP', proof);
+    assert.equal(res.status, 403);
+    // And stays fully usable as plain Bearer.
+    const bearer = await accessInfo().set('Authorization', unboundToken);
+    assert.equal(bearer.status, 200, JSON.stringify(bearer.body));
+  });
+
+  it('[DPN08] the batch route enforces the binding too', async function () {
+    const batch = await fwd(coreRequest.post(`/${username}`))
+      .set('Authorization', boundToken)
+      .send([{ method: 'events.get', params: {} }]);
+    // The bound token without a proof must not execute batch calls.
+    const results = batch.body.results ?? [];
+    const anyOk = results.some((r) => r.error == null);
+    assert.equal(anyOk, false, 'batch with a bound token and no proof must not succeed: ' + JSON.stringify(batch.body));
+  });
+
+  it('[DPN09] accesses.update cannot strip or alter the binding (wholesale clientData replace)', async function () {
+    // Rejected updates do not bump the access serial, so the base id
+    // stays addressable across them; the successful ones return the new
+    // composite id to reuse.
+    const upd = (id, body) => coreRequest
+      .put(`/${username}/accesses/${id}`).set('Authorization', personalToken).send(body);
+
+    const strip = await upd(boundAccessId, { clientData: { harmless: true } });
+    assert.equal(strip.status, 403, JSON.stringify(strip.body));
+    const alter = await upd(boundAccessId, { clientData: { dpop: { jkt: 'attacker-thumbprint' } } });
+    assert.equal(alter.status, 403, JSON.stringify(alter.body));
+    // Preserving the binding verbatim is allowed.
+    const keep = await upd(boundAccessId, { clientData: { dpop: { jkt: computeJkt(key.publicJwk) }, note: 'kept' } });
+    assert.equal(keep.status, 200, JSON.stringify(keep.body));
+    // An update that does not touch clientData is unaffected (use the new head id).
+    const rename = await upd(keep.body.access.id, { name: 'dpop-bound-app-renamed' });
+    assert.equal(rename.status, 200, JSON.stringify(rename.body));
+  });
+
+  it('[DPN10] a binding cannot be FORGED onto an unbound access via accesses.update', async function () {
+    const forge = await coreRequest
+      .put(`/${username}/accesses/${unboundAccessId}`)
+      .set('Authorization', personalToken)
+      .send({ clientData: { dpop: { jkt: 'attacker-thumbprint' } } });
+    assert.equal(forge.status, 403, JSON.stringify(forge.body));
+    // A clientData update that leaves dpop absent (as it was) is fine.
+    const ok = await coreRequest
+      .put(`/${username}/accesses/${unboundAccessId}`)
+      .set('Authorization', personalToken)
+      .send({ clientData: { note: 'plain' } });
+    assert.equal(ok.status, 200, JSON.stringify(ok.body));
+  });
+});

--- a/components/api-server/test/oauth2-e2e.test.js
+++ b/components/api-server/test/oauth2-e2e.test.js
@@ -662,6 +662,161 @@ describe('[OAUTH-E2E] OAuth 2.0 authorization-code flow (granular consent-offer 
     });
   });
 
+  describe('[OAUTH-E2E-DPOP] DPoP sender-constrained round-trip (RFC 9449)', function () {
+    const { webcrypto } = require('node:crypto');
+    const { subtle } = webcrypto;
+    const DPOP_HOST = 'api.example.test';
+
+    async function dpopKey () {
+      const pair = await subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+      const jwk = await subtle.exportKey('jwk', pair.publicKey);
+      return { pair, publicJwk: { kty: jwk.kty, crv: jwk.crv, x: jwk.x, y: jwk.y } };
+    }
+    async function proof (key, { htm, path, accessToken }) {
+      const b = (buf) => Buffer.from(buf).toString('base64url');
+      const header = { typ: 'dpop+jwt', alg: 'ES256', jwk: key.publicJwk };
+      const payload = {
+        jti: 'e2e-' + crypto.randomBytes(12).toString('hex'),
+        htm,
+        htu: `http://${DPOP_HOST}${path}`,
+        iat: Math.floor(Date.now() / 1000),
+        ...(accessToken != null ? { ath: crypto.createHash('sha256').update(accessToken).digest('base64url') } : {}),
+      };
+      const h = b(JSON.stringify(header)); const p = b(JSON.stringify(payload));
+      const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key.pair.privateKey, Buffer.from(`${h}.${p}`, 'utf8'));
+      return `${h}.${p}.${b(sig)}`;
+    }
+    // Reverse-proxy headers so the server reconstructs DPOP_HOST for htu
+    // while subdomain routing keeps seeing supertest's own Host.
+    const fwd = (req) => req.set('X-Forwarded-Host', DPOP_HOST).set('X-Forwarded-Proto', 'http');
+
+    // Each DPoP test needs its OWN open-link offer + client: re-accepting
+    // the SAME open-link offer as the same user currently fails
+    // (requester-side accepted-by bookkeeping is never cleared — tracked
+    // separately), so a shared offer would break the second test. Publish
+    // a fresh offer and register a fresh client per call.
+    async function freshClientAndOffer () {
+      const offerName = 'dpop-' + cuid().slice(-8);
+      const capUrl = await coreRequest
+        .post('/' + appUsername + '/events')
+        .set('Authorization', appToken)
+        .send({
+          streamIds: [':_cmc:apps:e2e-oauth'],
+          type: 'consent/request-cmc',
+          content: {
+            to: null,
+            capabilityRequested: true,
+            capability: { mode: 'open-link' },
+            request: {
+              title: { en: 'DPoP offer' },
+              description: { en: 'x' },
+              consent: { en: 'ok' },
+              permissions: [{ streamId: 'health', level: 'read' }],
+              allowUserChoice: true,
+            },
+            requesterMeta: { displayName: 'DPoP E2E', appId: 'oauth-e2e' },
+          },
+        })
+        .then((r) => { assert.equal(r.status, 201, JSON.stringify(r.body)); return r.body.event.content.capabilityUrl; });
+      const cid = 'app-dpop-' + cuid();
+      await storage.setClient(require('storages').platformDB, {
+        clientId: cid,
+        redirectUris: [REDIRECT_URI],
+        scope: ['cmc:' + offerName],
+        cmcOffers: { [offerName]: { capabilityUrl: capUrl } },
+        grantTypes: ['authorization_code'],
+        clientName: 'DPoP E2E App',
+        updatedAt: Date.now(),
+      });
+      return { cid, offerName };
+    }
+
+    // Drive authorize + accept to a fresh code on a dedicated offer.
+    async function toCode () {
+      const { cid, offerName } = await freshClientAndOffer();
+      const { verifier, challenge } = pkce();
+      const authRes = await coreRequest.get('/oauth2/authorize').query({
+        client_id: cid,
+        redirect_uri: REDIRECT_URI,
+        response_type: 'code',
+        state: 'csrf-dpop-' + cuid(),
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        scope: 'cmc:' + offerName,
+      });
+      const signedState = decodeURIComponent(authRes.headers.location.split('state=')[1].split('&')[0]);
+      const acceptRes = await coreRequest.post('/oauth2/authorize/accept').send({
+        state: signedState,
+        username,
+        userToken: personalToken,
+        grantedPermissions: [{ streamId: 'health', level: 'read' }],
+      });
+      assert.equal(acceptRes.status, 200, describeRes(acceptRes));
+      return { code: decodeURIComponent(acceptRes.body.redirectTo.match(/code=([^&]+)/)[1]), verifier, clientId: cid };
+    }
+
+    it('[OE21DP] proof at /token binds the access; the token works only WITH a proof; refresh keeps the key; replay is refused', async function () {
+      const key = await dpopKey();
+      const { code, verifier, clientId: dpopClientId } = await toCode();
+
+      // Token exchange carrying a DPoP proof → DPoP-bound token.
+      const tokenRes = await fwd(coreRequest.post('/oauth2/token'))
+        .type('form')
+        .set('DPoP', await proof(key, { htm: 'POST', path: '/oauth2/token' }))
+        .send({ grant_type: 'authorization_code', code, code_verifier: verifier, client_id: dpopClientId, redirect_uri: REDIRECT_URI });
+      assert.equal(tokenRes.status, 200, describeRes(tokenRes));
+      assert.equal(tokenRes.body.token_type, 'DPoP');
+      const accessToken = tokenRes.body.access_token;
+
+      // The bound token is unusable as plain Bearer.
+      const bearer = await coreRequest.get('/' + username + '/events').set('Authorization', accessToken);
+      assert.equal(bearer.status, 403, describeRes(bearer));
+
+      // With a valid proof it works.
+      const ok = await fwd(coreRequest.get('/' + username + '/events'))
+        .set('Authorization', 'DPoP ' + accessToken)
+        .set('DPoP', await proof(key, { htm: 'GET', path: '/' + username + '/events', accessToken }));
+      assert.equal(ok.status, 200, describeRes(ok));
+      assert.ok(Array.isArray(ok.body.events));
+
+      // Replaying that exact proof is refused (jti single-use).
+      const replayProof = await proof(key, { htm: 'GET', path: '/' + username + '/events', accessToken });
+      const first = await fwd(coreRequest.get('/' + username + '/events')).set('Authorization', 'DPoP ' + accessToken).set('DPoP', replayProof);
+      assert.equal(first.status, 200);
+      const replay = await fwd(coreRequest.get('/' + username + '/events')).set('Authorization', 'DPoP ' + accessToken).set('DPoP', replayProof);
+      assert.equal(replay.status, 403, describeRes(replay));
+
+      // Refresh with a proof by the SAME key keeps the binding.
+      const refreshRes = await fwd(coreRequest.post('/oauth2/token'))
+        .type('form')
+        .set('DPoP', await proof(key, { htm: 'POST', path: '/oauth2/token' }))
+        .send({ grant_type: 'refresh_token', refresh_token: tokenRes.body.refresh_token, client_id: dpopClientId });
+      assert.equal(refreshRes.status, 200, describeRes(refreshRes));
+      assert.equal(refreshRes.body.token_type, 'DPoP');
+      const rotated = refreshRes.body.access_token;
+      const rotatedOk = await fwd(coreRequest.get('/' + username + '/events'))
+        .set('Authorization', 'DPoP ' + rotated)
+        .set('DPoP', await proof(key, { htm: 'GET', path: '/' + username + '/events', accessToken: rotated }));
+      assert.equal(rotatedOk.status, 200, describeRes(rotatedOk));
+    });
+
+    it('[OE22DP] a stolen bound token + a DIFFERENT key cannot be used', async function () {
+      const key = await dpopKey();
+      const { code, verifier, clientId: dpopClientId } = await toCode();
+      const tokenRes = await fwd(coreRequest.post('/oauth2/token'))
+        .type('form')
+        .set('DPoP', await proof(key, { htm: 'POST', path: '/oauth2/token' }))
+        .send({ grant_type: 'authorization_code', code, code_verifier: verifier, client_id: dpopClientId, redirect_uri: REDIRECT_URI });
+      assert.equal(tokenRes.status, 200, describeRes(tokenRes));
+      const accessToken = tokenRes.body.access_token;
+      const thiefKey = await dpopKey();
+      const stolen = await fwd(coreRequest.get('/' + username + '/events'))
+        .set('Authorization', 'DPoP ' + accessToken)
+        .set('DPoP', await proof(thiefKey, { htm: 'GET', path: '/' + username + '/events', accessToken }));
+      assert.equal(stolen.status, 403, describeRes(stolen));
+    });
+  });
+
   describe('[OAUTH-E2E-WK] discovery doc', function () {
     it('[OE20] GET /.well-known/oauth-authorization-server returns RFC 8414 doc', async function () {
       const res = await coreRequest.get('/.well-known/oauth-authorization-server');
@@ -671,6 +826,7 @@ describe('[OAUTH-E2E] OAuth 2.0 authorization-code flow (granular consent-offer 
       assert.deepEqual(res.body.response_types_supported, ['code']);
       assert.deepEqual(res.body.code_challenge_methods_supported, ['S256']);
       assert.equal(res.body.authorization_response_iss_parameter_supported, true);
+      assert.deepEqual(res.body.dpop_signing_alg_values_supported, ['ES256']);
       assert.ok(res.body.scopes_supported.includes('cmc:*'),
         'discovery must advertise the cmc namespace: ' + JSON.stringify(res.body.scopes_supported));
     });

--- a/components/audit/src/ApiMethods.ts
+++ b/components/audit/src/ApiMethods.ts
@@ -79,6 +79,7 @@ const ALL_METHODS = [
   'oauth.token.issued.client_credentials',
   'oauth.token.refreshed',
   'oauth.token.reuse_detected',
+  'oauth.token.dpop_mismatch',
   'oauth.token.revoked'
 ];
 

--- a/components/business/src/MethodContext.ts
+++ b/components/business/src/MethodContext.ts
@@ -55,6 +55,21 @@ class MethodContext {
    */
   acceptStreamsQueryNonStringified: boolean | undefined;
 
+  /**
+   * Authorization scheme the caller used, when one was recognized.
+   * 'dpop' ⇒ the token came as `Authorization: DPoP <token>`; null for
+   * Bearer/bare/query auth (getAuth strips Bearer upstream on the http
+   * path). Drives the sender-constrained-token checks.
+   */
+  authScheme: 'dpop' | null;
+  /**
+   * The client-facing request line a DPoP proof must cover — set by the
+   * http transports (initContext). Transports that cannot carry a
+   * per-request proof (socket.io, hfs) leave it null, so a DPoP-bound
+   * access FAILS CLOSED there by construction.
+   */
+  requestSignatureTarget: { htm: string; htu: string } | null;
+
   constructor (source: ContextSource, username: string, auth: string | null, customAuthStepFn: CustomAuthFunction | null, headers: HttpHeaders, query: Record<string, unknown>, tracing: unknown) {
     this.source = source;
     this.user = { id: null, username };
@@ -65,6 +80,8 @@ class MethodContext {
     this.callerId = null;
     this.headers = headers;
     this.methodId = null;
+    this.authScheme = null;
+    this.requestSignatureTarget = null;
     if (auth != null) { this.parseAuth(auth); }
     this.originalQuery = structuredClone(query);
     if (this.originalQuery?.auth) { delete this.originalQuery.auth; }
@@ -87,6 +104,14 @@ class MethodContext {
    * assigning to `this.accessToken` and `this.callerId`.
    */
   parseAuth (auth: string) {
+    // RFC 9449 scheme: `DPoP <token>`. Recognized here (not in getAuth)
+    // so every transport that hands the raw header to a MethodContext —
+    // including the batch route, which skips getAuth — sees the scheme.
+    // Auth-scheme names compare case-insensitively (RFC 9110 §11.1).
+    if (/^dpop /i.test(auth)) {
+      this.authScheme = 'dpop';
+      auth = auth.substring(5).trim();
+    }
     this.accessToken = auth;
     // Sometimes, the auth string will look like this:
     //    'TOKEN CALLERID'
@@ -151,6 +176,11 @@ class MethodContext {
       if (this.access == null) { await this.retrieveAccessFromToken(storage); }
       const access = this.access;
       if (access == null) { throw new Error('AF: this.access != null'); }
+      // Sender-constrained (DPoP) accesses: enforce proof-of-possession
+      // for EVERY expansion, whatever the transport. Must run at this
+      // shared choke point — moving it to an http-only path would let a
+      // bound token be replayed over socket.io/hfs.
+      await this.checkDpopBinding();
       // Check if the session is valid; touch it.
       await this.checkSessionValid(storage);
       // Perform the custom auth step.
@@ -207,6 +237,58 @@ class MethodContext {
     if (access == null) return;
     const now = timestamp.now();
     if (access.expires != null && now > access.expires) { throw errors.forbidden('Access has expired.'); }
+  }
+
+  /**
+   * Enforce DPoP (RFC 9449) sender constraint. An access carrying a
+   * `clientData.dpop.jkt` binding is only usable with a valid DPoP
+   * proof signed by the bound key, covering THIS request (htm/htu) and
+   * THIS token (ath), with a single-use jti. An unbound access
+   * presented under the `DPoP` scheme is refused too — the token kind
+   * is fixed at issuance. Every refusal is the same uniform 403 (no
+   * oracle); reasons never leave the server.
+   */
+  async checkDpopBinding () {
+    const boundJkt = (this.access as { clientData?: { dpop?: { jkt?: unknown } } } | null)?.clientData?.dpop?.jkt;
+    const refused = () => {
+      const err = errors.invalidAccessToken('DPoP proof verification failed.', 403);
+      // Emitted as a WWW-Authenticate challenge by the http error layer.
+      err.httpHeaders = { 'WWW-Authenticate': 'DPoP algs="ES256", error="invalid_token"' };
+      return err;
+    };
+    if (typeof boundJkt !== 'string') {
+      if (this.authScheme === 'dpop') throw refused();
+      return;
+    }
+    const proofHeader = (this.headers as Record<string, unknown> | null)?.dpop;
+    const target = this.requestSignatureTarget;
+    if (proofHeader == null || target == null || this.accessToken == null) throw refused();
+    // Lazy requires: only sender-constrained requests pay for these, and
+    // business stays load-order-independent from the oauth2 component.
+    const { verifyDPoPProof, DPoPProofError } = require('oauth2/src/dpop.ts');
+    const { markDPoPJtiUsed } = require('oauth2/src/storage.ts');
+    const platform = require('storages').platformDB;
+    if (platform == null) throw errors.unexpectedError(new Error('platform storage unavailable for DPoP validation'));
+    let clockSkewSeconds = 120;
+    try {
+      const configured = require('@pryv/boiler').getConfigSync().get('oauth:dpop:clockSkewSeconds');
+      if (configured != null) clockSkewSeconds = Number(configured);
+    } catch { /* config not booted (unit contexts) — keep the default */ }
+    let verified;
+    try {
+      verified = await verifyDPoPProof(Array.isArray(proofHeader) ? null : proofHeader, {
+        htm: target.htm,
+        htu: target.htu,
+        accessToken: this.accessToken,
+        clockSkewSeconds,
+      });
+    } catch (err) {
+      if (err instanceof DPoPProofError) throw refused();
+      throw err;
+    }
+    if (verified.jkt !== boundJkt) throw refused();
+    const fresh = await markDPoPJtiUsed(platform, verified.jkt, verified.jti, Date.now() + 2 * clockSkewSeconds * 1000);
+    if (!fresh) throw refused();
   }
 
   /**

--- a/components/business/src/MethodContext.ts
+++ b/components/business/src/MethodContext.ts
@@ -69,6 +69,15 @@ class MethodContext {
    * access FAILS CLOSED there by construction.
    */
   requestSignatureTarget: { htm: string; htu: string } | null;
+  /**
+   * Set true once the request authenticated via a valid file
+   * `readToken` (HMAC over fileId + access.token). That HMAC is itself a
+   * server-issued possession proof for a single-file attachment read, so
+   * it substitutes for a DPoP proof on the attachment-download path —
+   * a `<img src>` / drag-drop / download GET cannot carry a DPoP header.
+   * Scoped to that capability only; never set for a general API call.
+   */
+  readTokenAuthenticated: boolean;
 
   constructor (source: ContextSource, username: string, auth: string | null, customAuthStepFn: CustomAuthFunction | null, headers: HttpHeaders, query: Record<string, unknown>, tracing: unknown) {
     this.source = source;
@@ -82,6 +91,7 @@ class MethodContext {
     this.methodId = null;
     this.authScheme = null;
     this.requestSignatureTarget = null;
+    this.readTokenAuthenticated = false;
     if (auth != null) { this.parseAuth(auth); }
     this.originalQuery = structuredClone(query);
     if (this.originalQuery?.auth) { delete this.originalQuery.auth; }
@@ -249,6 +259,10 @@ class MethodContext {
    * oracle); reasons never leave the server.
    */
   async checkDpopBinding () {
+    // A validated file readToken is itself the possession proof for the
+    // attachment-download capability (see readTokenAuthenticated) — that
+    // GET cannot carry a DPoP header, so the HMAC substitutes.
+    if (this.readTokenAuthenticated) return;
     const boundJkt = (this.access as { clientData?: { dpop?: { jkt?: unknown } } } | null)?.clientData?.dpop?.jkt;
     const refused = () => {
       const err = errors.invalidAccessToken('DPoP proof verification failed.', 403);

--- a/components/errors/src/APIError.ts
+++ b/components/errors/src/APIError.ts
@@ -20,6 +20,12 @@ class APIError extends Error {
   httpStatus: number;
   data: unknown;
   innerError: Error | null;
+  /**
+   * Optional response headers the http error layer must emit with this
+   * error (e.g. a WWW-Authenticate challenge). Never part of the JSON
+   * body.
+   */
+  httpHeaders?: Record<string, string>;
 
   constructor (id: string, message: string, options?: APIErrorOptions) {
     super(message);

--- a/components/middleware/src/initContext.ts
+++ b/components/middleware/src/initContext.ts
@@ -28,6 +28,18 @@ export default function initContext (storageLayer: unknown, customAuthStepFn: Cu
     };
     // We should not do this, but we're doing it.
     req.context = new MethodContext(contextSource, req.params.username, authorizationHeader, customAuthStepFn, req.headers, req.query, req.tracing);
+    // Sender-constrained (DPoP) accesses verify their per-request proof
+    // against the CLIENT-FACING request line. `originalUrl` is captured
+    // by express at app entry, before the subdomain/path rewrites
+    // mutate `req.url`. If no target can be built, it stays null and a
+    // DPoP-bound access fails closed.
+    try {
+      const { externalRequestUri } = require('oauth2/src/externalUri.ts');
+      (req.context as unknown as { requestSignatureTarget: unknown }).requestSignatureTarget = {
+        htm: req.method,
+        htu: externalRequestUri(req),
+      };
+    } catch { /* no Host header — leave null */ }
     // Convert the above promise into a callback.
     return req.context!
       .init()

--- a/components/oauth2/src/audit.ts
+++ b/components/oauth2/src/audit.ts
@@ -84,6 +84,7 @@ export type OAuthAuditPayload = {
   oldTokenId?: string;
   newTokenId?: string;
   attemptedBy?: string; // for oauth.code.reused — IP / fingerprint of the second attempt
+  dpopJkt?: string; // DPoP-bound issuances: RFC 7638 thumbprint of the bound key
   offerName?: string;
   offerCapabilityId?: string;
   reason?: string;

--- a/components/oauth2/src/audit.ts
+++ b/components/oauth2/src/audit.ts
@@ -50,6 +50,7 @@ export type OAuthAuditEvent =
   | 'oauth.token.issued.client_credentials'
   | 'oauth.token.refreshed'
   | 'oauth.token.reuse_detected'
+  | 'oauth.token.dpop_mismatch'
   | 'oauth.token.revoked';
 
 /**

--- a/components/oauth2/src/dpop.ts
+++ b/components/oauth2/src/dpop.ts
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright (C) Pryv https://pryv.com
+ * This file is part of Pryv.io and released under BSD-Clause-3 License
+ * Refer to LICENSE file
+ */
+
+/**
+ * DPoP (RFC 9449) proof verification — pure module, no HTTP and no
+ * storage. Verifies a `DPoP` header value (a compact JWS) against the
+ * request it claims to cover and derives the key's RFC 7638 thumbprint
+ * (`jkt`). Replay accounting (`jti` single-use) is the CALLER's job —
+ * this module only validates shape, signature and claims.
+ *
+ * Deliberately ES256-only (EC P-256), verification-only, and
+ * dependency-free on top of node:crypto webcrypto: the server never
+ * signs, and accepting exactly one algorithm removes the JWS
+ * alg-confusion surface (`none`, HMAC-with-public-key) by construction.
+ */
+
+import { createHash, webcrypto } from 'node:crypto';
+
+const { subtle } = webcrypto;
+
+/** Upper bound on an acceptable proof; a legitimate ES256 proof is <1 KB. */
+const MAX_PROOF_LENGTH = 4096;
+
+export interface VerifiedDPoPProof {
+  /** RFC 7638 JWK thumbprint (base64url) of the proof's public key. */
+  jkt: string;
+  /** The proof's unique identifier — caller enforces single use. */
+  jti: string;
+  /** The proof's issued-at (seconds since epoch, as claimed). */
+  iat: number;
+}
+
+export interface DPoPVerifyOptions {
+  /** Expected HTTP method (uppercase, e.g. 'POST'). */
+  htm: string;
+  /** Expected external request URI (compared without query/fragment). */
+  htu: string;
+  /** When present, the proof's `ath` must be base64url(sha256(accessToken)). */
+  accessToken?: string;
+  /** Acceptance window for `iat`, in seconds (± around now). */
+  clockSkewSeconds: number;
+  /** Injectable clock for tests (ms since epoch). */
+  now?: number;
+}
+
+/**
+ * Single error type for every verification failure: the HTTP layer maps
+ * it uniformly to `invalid_dpop_proof` (RFC 9449 §7.1) so responses
+ * carry no oracle; `reason` is for server-side logs only.
+ */
+export class DPoPProofError extends Error {
+  readonly code = 'invalid_dpop_proof';
+  readonly reason: string;
+  constructor (reason: string) {
+    super('DPoP proof verification failed');
+    this.reason = reason;
+  }
+}
+
+function fail (reason: string): never {
+  throw new DPoPProofError(reason);
+}
+
+function b64urlDecode (segment: string): Buffer {
+  if (!/^[A-Za-z0-9_-]+$/.test(segment)) fail('segment is not base64url');
+  return Buffer.from(segment, 'base64url');
+}
+
+function b64urlSha256 (input: string): string {
+  return createHash('sha256').update(input).digest('base64url');
+}
+
+function parseJsonObject (buf: Buffer, what: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(buf.toString('utf8'));
+  } catch {
+    fail(`${what} is not valid JSON`);
+  }
+  if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    fail(`${what} is not a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+interface EcPublicJwk { kty: 'EC', crv: 'P-256', x: string, y: string }
+
+/**
+ * Accept exactly a public EC P-256 key: coordinates must be 32-byte
+ * base64url values and any private-key member is rejected outright.
+ */
+function checkJwk (jwk: unknown): EcPublicJwk {
+  if (jwk == null || typeof jwk !== 'object' || Array.isArray(jwk)) fail('jwk missing or not an object');
+  const k = jwk as Record<string, unknown>;
+  if (k.kty !== 'EC') fail('jwk.kty must be EC');
+  if (k.crv !== 'P-256') fail('jwk.crv must be P-256');
+  if ('d' in k) fail('jwk carries private key material');
+  for (const coord of ['x', 'y'] as const) {
+    const v = k[coord];
+    if (typeof v !== 'string' || !/^[A-Za-z0-9_-]{43}$/.test(v)) fail(`jwk.${coord} is not a 32-byte base64url coordinate`);
+  }
+  return { kty: 'EC', crv: 'P-256', x: k.x as string, y: k.y as string };
+}
+
+/**
+ * RFC 7638 thumbprint: SHA-256 over the JSON of the key's REQUIRED
+ * members only, keys in lexicographic order, no whitespace.
+ */
+export function computeJkt (jwk: EcPublicJwk): string {
+  return b64urlSha256(`{"crv":"${jwk.crv}","kty":"${jwk.kty}","x":"${jwk.x}","y":"${jwk.y}"}`);
+}
+
+/**
+ * htu comparison form (RFC 9449 §4.3): scheme and host lowercased,
+ * default ports elided, query and fragment stripped. Paths compare
+ * verbatim — '/a' and '/a/' are different resources.
+ */
+export function normalizeHtu (uri: string): string {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    fail('htu is not an absolute URI');
+  }
+  // URL already lowercases scheme+host and elides default ports.
+  return url.origin + url.pathname;
+}
+
+/**
+ * Verify a DPoP proof. Returns the verified claims + jkt, or throws
+ * DPoPProofError. Callers MUST afterwards enforce jti single-use and,
+ * where a binding exists, compare jkt with the bound thumbprint.
+ */
+export async function verifyDPoPProof (proof: unknown, opts: DPoPVerifyOptions): Promise<VerifiedDPoPProof> {
+  if (typeof proof !== 'string' || proof.length === 0) fail('proof missing');
+  if (proof.length > MAX_PROOF_LENGTH) fail('proof too large');
+  const segments = proof.split('.');
+  if (segments.length !== 3 || segments.some((s) => s.length === 0)) fail('proof is not a compact JWS');
+  const [headerB64, payloadB64, signatureB64] = segments;
+
+  const header = parseJsonObject(b64urlDecode(headerB64), 'JWS header');
+  if (header.typ !== 'dpop+jwt') fail('header.typ must be dpop+jwt');
+  if (header.alg !== 'ES256') fail('header.alg must be ES256');
+  const jwk = checkJwk(header.jwk);
+
+  // ES256 JWS signatures are the raw 64-byte r||s concatenation —
+  // exactly the form webcrypto ECDSA verify expects.
+  const signature = b64urlDecode(signatureB64);
+  if (signature.length !== 64) fail('signature is not a raw ES256 signature');
+  let valid = false;
+  try {
+    // Import ONLY the sanitized members — never the raw header object.
+    const key = await subtle.importKey(
+      'jwk', jwk, { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']
+    );
+    valid = await subtle.verify(
+      { name: 'ECDSA', hash: 'SHA-256' },
+      key,
+      signature,
+      Buffer.from(`${headerB64}.${payloadB64}`, 'utf8')
+    );
+  } catch {
+    // e.g. coordinates not on the curve — a proof defect, not a server error.
+    fail('public key rejected');
+  }
+  if (!valid) fail('signature verification failed');
+
+  const payload = parseJsonObject(b64urlDecode(payloadB64), 'JWS payload');
+
+  const jti = payload.jti;
+  if (typeof jti !== 'string' || jti.length === 0 || jti.length > 256) fail('jti missing or out of bounds');
+
+  if (payload.htm !== opts.htm) fail('htm does not match the request method');
+  if (typeof payload.htu !== 'string' || normalizeHtu(payload.htu) !== normalizeHtu(opts.htu)) {
+    fail('htu does not match the request URI');
+  }
+
+  const iat = payload.iat;
+  const nowSeconds = Math.floor((opts.now ?? Date.now()) / 1000);
+  if (typeof iat !== 'number' || !Number.isFinite(iat)) fail('iat missing or not a number');
+  if (Math.abs(nowSeconds - iat) > opts.clockSkewSeconds) fail('iat outside the acceptance window');
+
+  if (opts.accessToken != null) {
+    if (payload.ath !== b64urlSha256(opts.accessToken)) fail('ath does not match the access token');
+  }
+
+  return { jkt: computeJkt(jwk), jti, iat };
+}

--- a/components/oauth2/src/externalUri.ts
+++ b/components/oauth2/src/externalUri.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright (C) Pryv https://pryv.com
+ * This file is part of Pryv.io and released under BSD-Clause-3 License
+ * Refer to LICENSE file
+ */
+
+/**
+ * Reconstruct the CLIENT-FACING request URI — the value a DPoP client
+ * signs into `htu`. Uses `req.originalUrl` (captured by express at app
+ * entry, BEFORE the in-app rewrites that mutate `req.url`) and honours
+ * the standard reverse-proxy forwarding headers, falling back to the
+ * transport's own view. Query and fragment are dropped — htu is
+ * compared without them (RFC 9449 §4.3).
+ */
+
+export interface UriSource {
+  protocol?: string;
+  originalUrl?: string;
+  url?: string;
+  headers?: Record<string, unknown>;
+}
+
+function firstHeaderValue (raw: unknown): string | null {
+  const v = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof v !== 'string' || v.length === 0) return null;
+  // Forwarding headers may carry a comma-joined proxy chain; the first
+  // entry is the client-facing edge.
+  return v.split(',')[0].trim();
+}
+
+export function externalRequestUri (req: UriSource): string {
+  const headers = req.headers ?? {};
+  const proto = firstHeaderValue(headers['x-forwarded-proto']) ?? req.protocol ?? 'http';
+  const host = firstHeaderValue(headers['x-forwarded-host']) ?? firstHeaderValue(headers.host);
+  if (host == null) throw new Error('cannot reconstruct the request URI: no Host header');
+  const rawPath = req.originalUrl ?? req.url ?? '/';
+  const path = rawPath.split('?')[0].split('#')[0];
+  return `${proto}://${host}${path.startsWith('/') ? path : '/' + path}`;
+}

--- a/components/oauth2/src/externalUri.ts
+++ b/components/oauth2/src/externalUri.ts
@@ -12,6 +12,14 @@
  * the standard reverse-proxy forwarding headers, falling back to the
  * transport's own view. Query and fragment are dropped — htu is
  * compared without them (RFC 9449 §4.3).
+ *
+ * TRUST ASSUMPTION: X-Forwarded-Host / X-Forwarded-Proto are taken as
+ * authoritative for the client-facing host/scheme. A deployment
+ * accepting DPoP MUST therefore run behind a proxy that overwrites these
+ * headers with the real values (see the `oauth.dpop` config comment) —
+ * the same trusted-proxy posture required for client-IP attribution.
+ * The path segment comes from `originalUrl`, not headers, so
+ * cross-endpoint replay stays blocked by the path compare regardless.
  */
 
 export interface UriSource {

--- a/components/oauth2/src/grants/authorization_code.ts
+++ b/components/oauth2/src/grants/authorization_code.ts
@@ -37,6 +37,14 @@ import { authenticateClient } from '../clientSecret.ts';
 export type AuthCodeDeps = {
   config: { get (key: string): unknown };
   platform: PlatformDB;
+  /**
+   * Required when the exchange carries a verified DPoP proof: writes
+   * the key-thumbprint binding onto the access pre-minted at /accept.
+   * The dispatcher guarantees it is present whenever dpopJkt is.
+   */
+  bindAccessDpop?: (params: {
+    userId: string; username: string; accessId: string; jkt: string;
+  }) => Promise<void>;
 };
 
 export type GrantParams = {
@@ -67,6 +75,8 @@ function lifetimes (config: { get (key: string): unknown }) {
 export async function handleAuthorizationCode (
   deps: AuthCodeDeps,
   params: GrantParams,
+  /** RFC 7638 thumbprint of a proof VERIFIED by the dispatcher, or null. */
+  dpopJkt: string | null = null,
 ): Promise<
   | { ok: true; body: Record<string, unknown> }
   | { ok: false; status: number; error: string; description?: string }
@@ -133,6 +143,22 @@ export async function handleAuthorizationCode (
     return { ok: false, status: 500, error: 'server_error', description: 'code row missing access details (accept-time provisioning skipped?)' };
   }
 
+  // DPoP binding (RFC 9449 §5): stamp the pre-minted access with the
+  // proof key's thumbprint BEFORE issuing any credential — a binding
+  // failure must not leave a bound-looking chain with an unbound
+  // access. On failure the code is already consumed (single-use); the
+  // client re-authorizes, which is the safe direction.
+  if (dpopJkt != null) {
+    if (typeof deps.bindAccessDpop !== 'function') {
+      return { ok: false, status: 500, error: 'server_error', description: 'DPoP binding is not wired on this deployment' };
+    }
+    try {
+      await deps.bindAccessDpop({ userId: row.userId, username: row.username, accessId: row.accessId, jkt: dpopJkt });
+    } catch {
+      return { ok: false, status: 500, error: 'server_error', description: 'failed to bind the access to the DPoP key' };
+    }
+  }
+
   // Mint refresh token. Sliding TTL with absolute cap.
   const { accessTokenTTL, refreshTokenTTL, refreshTokenAbsoluteTTL } = lifetimes(deps.config);
   const now = Date.now();
@@ -151,6 +177,7 @@ export async function handleAuthorizationCode (
     // and carries this session's granted subset for the re-mints.
     ...(row.dataGrantAccessId != null ? { dataGrantAccessId: row.dataGrantAccessId } : {}),
     ...(row.permissions != null ? { permissions: row.permissions } : {}),
+    ...(dpopJkt != null ? { jkt: dpopJkt } : {}),
   });
 
   await audit('oauth.code.exchanged', {
@@ -164,13 +191,14 @@ export async function handleAuthorizationCode (
     userId: row.userId,
     grantedScope: row.scope,
     accessId: row.accessId,
+    ...(dpopJkt != null ? { dpopJkt } : {}),
   });
 
   return {
     ok: true,
     body: {
       access_token: row.accessToken,
-      token_type: 'Bearer',
+      token_type: dpopJkt != null ? 'DPoP' : 'Bearer',
       expires_in: accessTokenTTL,
       refresh_token: refreshToken,
       scope: row.scope.join(' '),

--- a/components/oauth2/src/grants/refresh_token.ts
+++ b/components/oauth2/src/grants/refresh_token.ts
@@ -75,6 +75,12 @@ export type MintRefreshedAccess = (params: {
    */
   dataGrantAccessId?: string;
   permissions?: Array<Record<string, unknown>>;
+  /**
+   * DPoP-bound chains: the RFC 7638 thumbprint the chain is bound to.
+   * The mint callback stamps it onto the new access so the resource
+   * server can enforce proof-of-possession on every request.
+   */
+  jkt?: string;
 }) => Promise<{ accessId: string; accessToken: string; apiEndpoint: string }>;
 
 /**
@@ -124,6 +130,8 @@ function lifetimes (config: { get (key: string): unknown }) {
 export async function handleRefreshToken (
   deps: RefreshTokenDeps,
   params: RefreshGrantParams,
+  /** RFC 7638 thumbprint of a proof VERIFIED by the dispatcher, or null. */
+  dpopJkt: string | null = null,
 ): Promise<
   | { ok: true; body: Record<string, unknown> }
   | { ok: false; status: number; error: string; description?: string }
@@ -213,6 +221,18 @@ export async function handleRefreshToken (
     return { ok: false, status: auth.status, error: auth.error, description: auth.description };
   }
 
+  // DPoP binding continuity (RFC 9449 §5): a bound chain must rotate
+  // with a proof by the SAME key; an unbound chain can never acquire a
+  // binding mid-life (the kind is fixed at issuance). Uniform failure
+  // body either way. NOTE the row is already consumed above — a failed
+  // check burns the rotation, which is the safe direction: a thief
+  // holding the refresh token but not the key can at worst force a
+  // re-authorization, never take over the chain.
+  const boundJkt = typeof row.jkt === 'string' ? row.jkt : null;
+  if ((boundJkt != null && dpopJkt !== boundJkt) || (boundJkt == null && dpopJkt != null)) {
+    return { ok: false, status: 400, error: 'invalid_dpop_proof', description: 'DPoP proof verification failed' };
+  }
+
   // Enforce the absolute-lifetime cap BEFORE minting anything. Checking
   // after the mint would leave an orphan access row behind on a
   // cap-exceeded refresh (the access is minted, then the chain is
@@ -237,6 +257,7 @@ export async function handleRefreshToken (
       expiresAt: accessExpiresAt,
       ...(row.dataGrantAccessId != null ? { dataGrantAccessId: row.dataGrantAccessId } : {}),
       ...(row.permissions != null ? { permissions: row.permissions } : {}),
+      ...(boundJkt != null ? { jkt: boundJkt } : {}),
     });
   } catch (err: unknown) {
     if ((err as { code?: string } | null)?.code === 'data-grant-revoked') {
@@ -270,6 +291,7 @@ export async function handleRefreshToken (
     absoluteExpiresAt: row.absoluteExpiresAt,
     ...(row.dataGrantAccessId != null ? { dataGrantAccessId: row.dataGrantAccessId } : {}),
     ...(row.permissions != null ? { permissions: row.permissions } : {}),
+    ...(boundJkt != null ? { jkt: boundJkt } : {}),
   });
 
   await audit('oauth.token.refreshed', {
@@ -283,13 +305,14 @@ export async function handleRefreshToken (
     userId: row.userId,
     grantedScope: row.scope,
     accessId: access.accessId,
+    ...(boundJkt != null ? { dpopJkt: boundJkt } : {}),
   });
 
   return {
     ok: true,
     body: {
       access_token: access.accessToken,
-      token_type: 'Bearer',
+      token_type: boundJkt != null ? 'DPoP' : 'Bearer',
       expires_in: accessTokenTTL,
       refresh_token: newRefresh,
       scope: row.scope.join(' '),

--- a/components/oauth2/src/grants/refresh_token.ts
+++ b/components/oauth2/src/grants/refresh_token.ts
@@ -230,6 +230,16 @@ export async function handleRefreshToken (
   // re-authorization, never take over the chain.
   const boundJkt = typeof row.jkt === 'string' ? row.jkt : null;
   if ((boundJkt != null && dpopJkt !== boundJkt) || (boundJkt == null && dpopJkt != null)) {
+    // The row is already consumed (single-use), so this rotation is burned —
+    // the safe direction: a thief holding only the refresh token cannot take
+    // over the chain. Audit it distinctly so the next legitimate refresh's
+    // reuse_detected is not misread as the root cause.
+    await audit('oauth.token.dpop_mismatch', {
+      clientId: row.clientId,
+      userId: row.userId,
+      ...(row.dataGrantAccessId != null ? { dataGrantAccessId: row.dataGrantAccessId } : {}),
+      reason: boundJkt == null ? 'proof-on-unbound-chain' : 'wrong-key',
+    });
     return { ok: false, status: 400, error: 'invalid_dpop_proof', description: 'DPoP proof verification failed' };
   }
 

--- a/components/oauth2/src/routes.ts
+++ b/components/oauth2/src/routes.ts
@@ -90,6 +90,15 @@ export type Deps = {
   revokeChain?: (params: {
     userId: string; username: string; clientId: string; dataGrantAccessId?: string;
   }) => Promise<void>;
+  /**
+   * Write the DPoP key-thumbprint binding onto the access pre-minted at
+   * /accept (authorization_code + DPoP proof at /token). Storage-layer-
+   * direct. If absent, DPoP token requests fail with server_error —
+   * wire it wherever the auth flow deps are wired.
+   */
+  bindAccessDpop?: (params: {
+    userId: string; username: string; accessId: string; jkt: string;
+  }) => Promise<void>;
 };
 
 /**
@@ -154,6 +163,7 @@ export function registerRoutes (app: { get?: Function; post?: Function; options?
       mintClientAccess: deps.mintClientAccess,
       resolveAccountUserId: deps.resolveAccountUserId,
       revokeChain: deps.revokeChain,
+      bindAccessDpop: deps.bindAccessDpop,
     }));
 }
 

--- a/components/oauth2/src/routes/token.ts
+++ b/components/oauth2/src/routes/token.ts
@@ -23,10 +23,22 @@ import type { PlatformDB } from '../../../../storages/interfaces/platformStorage
 import { handleAuthorizationCode } from '../grants/authorization_code.ts';
 import { handleRefreshToken } from '../grants/refresh_token.ts';
 import { handleClientCredentials } from '../grants/client_credentials.ts';
+import { verifyDPoPProof, DPoPProofError } from '../dpop.ts';
+import { externalRequestUri } from '../externalUri.ts';
+import { markDPoPJtiUsed } from '../storage.ts';
 
 export type TokenDeps = {
   config: { get (key: string): unknown };
   platform: PlatformDB;
+  /**
+   * Required for DPoP-bound authorization_code exchanges: write the
+   * key-thumbprint binding onto the access that was pre-minted at
+   * /authorize/accept (the proof only appears here, at /token).
+   * Storage-direct — wired in the api-server layer.
+   */
+  bindAccessDpop?: (params: {
+    userId: string; username: string; accessId: string; jkt: string;
+  }) => Promise<void>;
   /** Required when grant_type=refresh_token is dispatched. */
   mintRefreshedAccess?: (params: {
     userId: string; username: string; clientId: string; scope: string[]; expiresAt: number;
@@ -79,11 +91,55 @@ export function handleToken (deps: TokenDeps) {
     const basic = decodeBasicAuth(req.headers?.authorization);
 
     let outcome;
-    if (grantType === 'authorization_code') {
-      outcome = await handleAuthorizationCode(
-        { config: deps.config, platform: deps.platform },
-        { ...body, basic },
-      );
+    // DPoP (RFC 9449 §5): a proof on the token request opts this
+    // issuance into key binding. Verified BEFORE any grant runs, so a
+    // bad proof burns nothing (no code/refresh consumed). The proof
+    // covers this endpoint (no ath — no access token exists yet) and
+    // its jti is burned atomically: of two concurrent identical proofs
+    // exactly one proceeds.
+    let dpopJkt: string | null = null;
+    const dpopHeader = req.headers?.dpop;
+    if (dpopHeader != null) {
+      const clockSkewSeconds = Number(deps.config.get('oauth:dpop:clockSkewSeconds') ?? 120);
+      try {
+        const verified = await verifyDPoPProof(
+          Array.isArray(dpopHeader) ? null : dpopHeader,
+          { htm: 'POST', htu: externalRequestUri(req), clockSkewSeconds },
+        );
+        const fresh = await markDPoPJtiUsed(
+          deps.platform, verified.jkt, verified.jti, Date.now() + 2 * clockSkewSeconds * 1000,
+        );
+        if (!fresh) throw new DPoPProofError('jti replayed');
+        dpopJkt = verified.jkt;
+      } catch (err: unknown) {
+        // Uniform response for every proof defect — reasons stay server-side.
+        if (err instanceof DPoPProofError) {
+          outcome = { ok: false as const, status: 400, error: 'invalid_dpop_proof', description: 'DPoP proof verification failed' };
+        } else {
+          outcome = { ok: false as const, status: 500, error: 'server_error', description: 'DPoP proof processing failed' };
+        }
+      }
+    }
+
+    if (outcome != null) {
+      // fall through to the response section with the DPoP failure
+    } else if (grantType === 'authorization_code') {
+      if (dpopJkt != null && typeof deps.bindAccessDpop !== 'function') {
+        // Advertised-but-not-wired server misconfiguration (see the
+        // mint-dep guards below) — refuse BEFORE the grant consumes the
+        // code, so the client can retry without re-authorizing.
+        outcome = { ok: false, status: 500, error: 'server_error', description: 'DPoP binding is not wired on this deployment' };
+      } else {
+        outcome = await handleAuthorizationCode(
+          {
+            config: deps.config,
+            platform: deps.platform,
+            ...(deps.bindAccessDpop != null ? { bindAccessDpop: deps.bindAccessDpop } : {}),
+          },
+          { ...body, basic },
+          dpopJkt,
+        );
+      }
     } else if (grantType === 'refresh_token') {
       if (typeof deps.mintRefreshedAccess !== 'function') {
         // Operator misconfiguration, not a client error: the grant handler
@@ -101,8 +157,14 @@ export function handleToken (deps: TokenDeps) {
             ...(deps.revokeChain != null ? { revokeChain: deps.revokeChain } : {}),
           },
           { ...body, basic },
+          dpopJkt,
         );
       }
+    } else if (dpopJkt != null && grantType === 'client_credentials') {
+      // Not supported for this grant in v1 — refuse loudly rather than
+      // silently issuing an unbound token to a client that asked for
+      // binding.
+      outcome = { ok: false, status: 400, error: 'invalid_request', description: 'DPoP is not supported for the client_credentials grant' };
     } else if (grantType === 'client_credentials') {
       if (typeof deps.mintClientAccess !== 'function' || typeof deps.resolveAccountUserId !== 'function') {
         // Server misconfiguration (advertised-but-not-wired), not a client

--- a/components/oauth2/src/storage.ts
+++ b/components/oauth2/src/storage.ts
@@ -127,6 +127,14 @@ export interface OAuthRefresh {
    */
   dataGrantAccessId?: string;
   permissions?: GrantPermission[];
+  /**
+   * DPoP binding (RFC 9449): the RFC 7638 thumbprint of the client key
+   * this chain is bound to. Set at issuance when the token request
+   * carried a valid DPoP proof; every rotation must present a proof by
+   * the SAME key, and the re-minted access inherits the binding. Absent
+   * on Bearer chains — a chain never changes kind after issuance.
+   */
+  jkt?: string;
 }
 
 /**
@@ -149,6 +157,7 @@ const PREFIX_CLIENT = 'oauth-client/';
 const PREFIX_CODE = 'oauth-code/';
 const PREFIX_REFRESH = 'oauth-refresh/';
 const PREFIX_REFRESH_USED = 'oauth-refresh-used/';
+const PREFIX_DPOP_JTI = 'dpop-jti/';
 
 // --- Client metadata (indefinite, cluster-wide) --- //
 
@@ -271,6 +280,20 @@ export async function markRefreshConsumed (
 export async function getRefreshConsumed (platform: PlatformDB, coreId: string, token: string): Promise<OAuthRefreshUsed | null> {
   const entry = await platform.getAccessState(refreshUsedKey(coreId, token));
   return entry == null ? null : (entry.value as OAuthRefreshUsed);
+}
+
+/**
+ * DPoP jti single-use marker (RFC 9449 §11.1 replay prevention). Atomic
+ * first-writer-wins: returns true when THIS call recorded the jti,
+ * false when it was already seen — two concurrent identical proofs
+ * yield exactly one true. TTL covers the proof's iat acceptance window;
+ * past it the iat check rejects the replay anyway. Swept with the rest
+ * of the access-state keyspace.
+ */
+export async function markDPoPJtiUsed (
+  platform: PlatformDB, jkt: string, jti: string, expiresAt: number,
+): Promise<boolean> {
+  return platform.setAccessStateIfAbsent(PREFIX_DPOP_JTI + jkt + '/' + jti, 1, expiresAt);
 }
 
 // --- Key helpers (owned here, NOT in the engine) --- //

--- a/components/oauth2/src/wellKnown.ts
+++ b/components/oauth2/src/wellKnown.ts
@@ -60,6 +60,10 @@ export function buildDiscoveryDocument (cfg: DiscoveryConfig): Record<string, un
     // PKCE is mandatory for all clients.
     // RFC 9207 — iss parameter in authorization response.
     authorization_response_iss_parameter_supported: true,
+    // RFC 9449 §5.1 — DPoP proof signing algorithms the server accepts.
+    // A client that presents a DPoP proof on /oauth2/token receives a
+    // sender-constrained (DPoP) token; omitting it yields a Bearer token.
+    dpop_signing_alg_values_supported: ['ES256'],
     // Cache headers + non-standard `apiEndpoint` extension are
     // implementation details, not advertised in the discovery doc.
   };

--- a/components/oauth2/test/dpop.test.js
+++ b/components/oauth2/test/dpop.test.js
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright (C) Pryv https://pryv.com
+ * This file is part of Pryv.io and released under BSD-Clause-3 License
+ * Refer to LICENSE file
+ */
+
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+const assert = require('node:assert/strict');
+const { createHash, webcrypto } = require('node:crypto');
+const { verifyDPoPProof, computeJkt, normalizeHtu, DPoPProofError } = require('../src/dpop.ts');
+
+const { subtle } = webcrypto;
+
+const b64url = (buf) => Buffer.from(buf).toString('base64url');
+
+async function makeKeyPair () {
+  const pair = await subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+  const jwk = await subtle.exportKey('jwk', pair.publicKey);
+  return { pair, publicJwk: { kty: jwk.kty, crv: jwk.crv, x: jwk.x, y: jwk.y } };
+}
+
+async function signProof (pair, header, payload) {
+  const h = b64url(JSON.stringify(header));
+  const p = b64url(JSON.stringify(payload));
+  const sig = await subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' }, pair.privateKey, Buffer.from(`${h}.${p}`, 'utf8')
+  );
+  return `${h}.${p}.${b64url(sig)}`;
+}
+
+/** Build a valid proof, with per-call overrides for header/payload. */
+async function makeProof (key, opts = {}) {
+  const header = { typ: 'dpop+jwt', alg: 'ES256', jwk: key.publicJwk, ...opts.header };
+  const payload = {
+    jti: 'jti-' + Math.random().toString(36).slice(2),
+    htm: 'POST',
+    htu: 'https://api.example.com/oauth2/token',
+    iat: Math.floor(NOW / 1000),
+    ...opts.payload,
+  };
+  return signProof(key.pair, header, payload);
+}
+
+const NOW = 1_700_000_000_000; // fixed clock — tests are deterministic
+const OPTS = {
+  htm: 'POST',
+  htu: 'https://api.example.com/oauth2/token',
+  clockSkewSeconds: 120,
+  now: NOW,
+};
+
+async function rejects (proof, opts, reasonPattern) {
+  await assert.rejects(
+    () => verifyDPoPProof(proof, { ...OPTS, ...opts }),
+    (err) => {
+      assert.ok(err instanceof DPoPProofError, `expected DPoPProofError, got ${err?.constructor?.name}: ${err?.message}`);
+      assert.equal(err.code, 'invalid_dpop_proof');
+      if (reasonPattern) assert.match(err.reason, reasonPattern);
+      return true;
+    }
+  );
+}
+
+describe('[OAUTH-DPV] DPoP proof verification (RFC 9449)', () => {
+  let key;
+  before(async () => { key = await makeKeyPair(); });
+
+  it('[DPV01] a valid proof verifies and returns jkt + jti + iat', async () => {
+    const proof = await makeProof(key, { payload: { jti: 'the-jti' } });
+    const res = await verifyDPoPProof(proof, OPTS);
+    assert.equal(res.jti, 'the-jti');
+    assert.equal(res.iat, Math.floor(NOW / 1000));
+    // Independent RFC 7638 computation: sha256 of the canonical
+    // lexicographic required-members JSON.
+    const canonical = `{"crv":"${key.publicJwk.crv}","kty":"${key.publicJwk.kty}","x":"${key.publicJwk.x}","y":"${key.publicJwk.y}"}`;
+    assert.equal(res.jkt, createHash('sha256').update(canonical).digest('base64url'));
+    assert.equal(res.jkt, computeJkt(key.publicJwk));
+  });
+
+  it('[DPV02] a tampered payload fails signature verification', async () => {
+    const proof = await makeProof(key);
+    const [h, p, s] = proof.split('.');
+    const tampered = JSON.parse(Buffer.from(p, 'base64url').toString());
+    tampered.htu = 'https://evil.example.com/oauth2/token';
+    await rejects(`${h}.${b64url(JSON.stringify(tampered))}.${s}`, { htu: 'https://evil.example.com/oauth2/token' }, /signature/);
+  });
+
+  it('[DPV03] wrong typ is rejected', async () => {
+    await rejects(await makeProof(key, { header: { typ: 'JWT' } }), {}, /typ/);
+  });
+
+  it('[DPV04] alg confusion is rejected: none and HS256', async () => {
+    await rejects(await makeProof(key, { header: { alg: 'none' } }), {}, /alg/);
+    await rejects(await makeProof(key, { header: { alg: 'HS256' } }), {}, /alg/);
+  });
+
+  it('[DPV05] private key material in the jwk is rejected', async () => {
+    const jwkWithD = { ...key.publicJwk, d: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' };
+    await rejects(await makeProof(key, { header: { jwk: jwkWithD } }), {}, /private/);
+  });
+
+  it('[DPV06] htm mismatch is rejected', async () => {
+    await rejects(await makeProof(key, { payload: { htm: 'GET' } }), {}, /htm/);
+  });
+
+  it('[DPV07] htu: query is ignored, default port elided, host case-folded; path mismatch rejected', async () => {
+    const q = await makeProof(key, { payload: { htu: 'https://API.example.com:443/oauth2/token?state=x#frag' } });
+    const res = await verifyDPoPProof(q, OPTS);
+    assert.ok(res.jkt);
+    await rejects(await makeProof(key, { payload: { htu: 'https://api.example.com/oauth2/token/' } }), {}, /htu/);
+    await rejects(await makeProof(key, { payload: { htu: '/oauth2/token' } }), {}, /htu|URI/);
+  });
+
+  it('[DPV08] iat outside the ±skew window is rejected, inside passes', async () => {
+    const sec = Math.floor(NOW / 1000);
+    await rejects(await makeProof(key, { payload: { iat: sec - 121 } }), {}, /iat/);
+    await rejects(await makeProof(key, { payload: { iat: sec + 121 } }), {}, /iat/);
+    await verifyDPoPProof(await makeProof(key, { payload: { iat: sec - 119 } }), OPTS);
+    await verifyDPoPProof(await makeProof(key, { payload: { iat: sec + 119 } }), OPTS);
+  });
+
+  it('[DPV09] ath binds the proof to the access token', async () => {
+    const token = 'the-access-token';
+    const ath = createHash('sha256').update(token).digest('base64url');
+    const good = await makeProof(key, { payload: { ath } });
+    await verifyDPoPProof(good, { ...OPTS, accessToken: token });
+    // Wrong token → mismatch; missing ath → mismatch.
+    await rejects(good, { accessToken: 'another-token' }, /ath/);
+    await rejects(await makeProof(key), { accessToken: token }, /ath/);
+    // A proof carrying ath still verifies when the caller expects none
+    // (token endpoint: no token exists yet).
+    await verifyDPoPProof(good, OPTS);
+  });
+
+  it('[DPV10] malformed inputs are rejected: not a string, bad JWS shape, oversized, garbage segments', async () => {
+    await rejects(null, {}, /missing/);
+    await rejects('only.two', {}, /compact JWS/);
+    await rejects('a.b.c.d', {}, /compact JWS/);
+    await rejects('x'.repeat(5000), {}, /too large/);
+    await rejects('!!.??.!!', {}, /base64url/);
+    const [h, , s] = (await makeProof(key)).split('.');
+    await rejects(`${h}.${b64url('"just a string"')}.${s}`, {}, /JSON object|signature/);
+  });
+
+  it('[DPV11] jti missing or out of bounds is rejected', async () => {
+    await rejects(await makeProof(key, { payload: { jti: undefined } }), {}, /jti/);
+    await rejects(await makeProof(key, { payload: { jti: '' } }), {}, /jti/);
+    await rejects(await makeProof(key, { payload: { jti: 'x'.repeat(300) } }), {}, /jti/);
+  });
+
+  it('[DPV12] a key from a DIFFERENT pair fails verification (signature, not shape)', async () => {
+    const otherKey = await makeKeyPair();
+    // Proof signed with key A but advertising key B in the header.
+    const proof = await makeProof({ pair: key.pair, publicJwk: otherKey.publicJwk });
+    await rejects(proof, {}, /signature/);
+  });
+
+  it('[DPV13] off-curve public key coordinates are rejected as a proof defect, not a crash', async () => {
+    const badJwk = { ...key.publicJwk, x: b64url(Buffer.alloc(32, 7)) };
+    await rejects(await makeProof(key, { header: { jwk: badJwk } }), {}, /key|signature/);
+  });
+
+  it('[DPV14] normalizeHtu is exported and stable for the enforcement layer', () => {
+    assert.equal(normalizeHtu('HTTPS://Api.Example.com:443/a/B?q=1#f'), 'https://api.example.com/a/B');
+    assert.equal(normalizeHtu('http://host:80/x'), 'http://host/x');
+    assert.equal(normalizeHtu('http://host:8080/x'), 'http://host:8080/x');
+  });
+});

--- a/components/oauth2/test/token-dpop.test.js
+++ b/components/oauth2/test/token-dpop.test.js
@@ -1,0 +1,324 @@
+/**
+ * @license
+ * Copyright (C) Pryv https://pryv.com
+ * This file is part of Pryv.io and released under BSD-Clause-3 License
+ * Refer to LICENSE file
+ */
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+/**
+ * [OAUTH-TKN-DP] POST /oauth2/token — DPoP (RFC 9449) key binding.
+ *
+ * Proof handling at the dispatcher (verify-before-any-grant, jti
+ * single-use), authorization_code binding via bindAccessDpop, refresh
+ * rotation continuity (same key, no mid-chain upgrade/downgrade), and
+ * the client_credentials refusal.
+ */
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const { webcrypto } = require('node:crypto');
+const { handleToken } = require('../src/routes/token.ts');
+const { setCode, setRefresh, getRefresh } = require('../src/storage.ts');
+const { computeJkt } = require('../src/dpop.ts');
+
+const { subtle } = webcrypto;
+const ISSUER = 'https://reg.pryv.me';
+const CORE_ID = 'core-a';
+const TOKEN_HOST = 'api.example.com';
+const TOKEN_HTU = `http://${TOKEN_HOST}/oauth2/token`;
+
+function fakeConfig (overrides = {}) {
+  const m = {
+    'service:api': ISSUER,
+    'core:id': CORE_ID,
+    'oauth:accessTokenTTL': 3600,
+    'oauth:refreshTokenTTL': 30 * 24 * 3600,
+    'oauth:refreshTokenAbsoluteTTL': 90 * 24 * 3600,
+    'oauth:dpop:clockSkewSeconds': 120,
+    ...overrides,
+  };
+  return { get: (k) => m[k] };
+}
+
+function fakePlatform () {
+  const kv = new Map();
+  const state = new Map();
+  return {
+    async setPlatformKv (k, v) { kv.set(k, v); },
+    async getPlatformKv (k) { return kv.has(k) ? kv.get(k) : null; },
+    async deletePlatformKv (k) { kv.delete(k); },
+    async listPlatformKvKeys (p) { return Array.from(kv.keys()).filter((k) => k.startsWith(p)); },
+    async setAccessState (k, v, exp) { state.set(k, { value: v, expiresAt: exp }); },
+    async setAccessStateIfAbsent (k, v, exp) {
+      const e = state.get(k);
+      if (e != null && Date.now() <= e.expiresAt) return false;
+      state.set(k, { value: v, expiresAt: exp });
+      return true;
+    },
+    async getAccessState (k) {
+      const e = state.get(k);
+      if (e == null) return null;
+      if (Date.now() > e.expiresAt) { state.delete(k); return null; }
+      return e;
+    },
+    async deleteAccessState (k) { state.delete(k); },
+    async consumeAccessState (k) {
+      const e = state.get(k); state.delete(k);
+      if (e == null) return null;
+      if (Date.now() > e.expiresAt) return null;
+      return e;
+    },
+  };
+}
+
+function fakeRes () {
+  const res = {
+    statusCode: 0,
+    headers: {},
+    body: null,
+    setHeader (k, v) { this.headers[k] = v; },
+    end (payload) { this.body = JSON.parse(payload); },
+  };
+  return res;
+}
+
+async function makeKeyPair () {
+  const pair = await subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+  const jwk = await subtle.exportKey('jwk', pair.publicKey);
+  return { pair, publicJwk: { kty: jwk.kty, crv: jwk.crv, x: jwk.x, y: jwk.y } };
+}
+
+async function makeProof (key, overrides = {}) {
+  const b64url = (buf) => Buffer.from(buf).toString('base64url');
+  const header = { typ: 'dpop+jwt', alg: 'ES256', jwk: key.publicJwk };
+  const payload = {
+    jti: 'jti-' + crypto.randomUUID(),
+    htm: 'POST',
+    htu: TOKEN_HTU,
+    iat: Math.floor(Date.now() / 1000),
+    ...overrides,
+  };
+  const h = b64url(JSON.stringify(header));
+  const p = b64url(JSON.stringify(payload));
+  const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key.pair.privateKey, Buffer.from(`${h}.${p}`, 'utf8'));
+  return `${h}.${p}.${b64url(sig)}`;
+}
+
+function tokenReq (body, dpopProof) {
+  return {
+    body,
+    originalUrl: '/oauth2/token',
+    url: '/oauth2/token',
+    headers: { host: TOKEN_HOST, ...(dpopProof != null ? { dpop: dpopProof } : {}) },
+  };
+}
+
+const VERIFIER = 'verifier-1234567890-abcdefg-hijklmnop';
+function challenge (verifier) {
+  return crypto.createHash('sha256').update(verifier).digest('base64')
+    .replace(/=+$/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+async function seedCode (platform, code) {
+  await setCode(platform, code, {
+    clientId: 'myapp',
+    redirectUri: 'https://app.example/cb',
+    codeChallenge: challenge(VERIFIER),
+    codeChallengeMethod: 'S256',
+    userId: 'u-alice',
+    username: 'alice',
+    scope: ['pryv:read'],
+    expiresAt: Date.now() + 60_000,
+    accessId: 'acc-u-alice',
+    accessToken: 'tok-u-alice-myapp',
+    apiEndpoint: 'https://tok@alice.pryv.me/',
+  });
+}
+
+async function seedRefresh (platform, token, extra = {}) {
+  const now = Date.now();
+  await setRefresh(platform, CORE_ID, token, {
+    clientId: 'myapp',
+    userId: 'u-alice',
+    username: 'alice',
+    scope: ['pryv:read'],
+    issuedAt: now,
+    lastUsedAt: now,
+    expiresAt: now + 3600_000,
+    absoluteExpiresAt: now + 7200_000,
+    dataGrantAccessId: 'dg-1',
+    permissions: [{ streamId: 'health', level: 'read' }],
+    ...extra,
+  });
+}
+
+const MINT_OK = async () => ({ accessId: 'acc-new', accessToken: 'tok-new', apiEndpoint: 'https://new@alice.pryv.me/' });
+
+function codeBody (code) {
+  return { grant_type: 'authorization_code', code, code_verifier: VERIFIER, client_id: 'myapp', redirect_uri: 'https://app.example/cb' };
+}
+
+describe('[OAUTH-TKN-DP] /oauth2/token — DPoP key binding', () => {
+  let key;
+  before(async () => { key = await makeKeyPair(); });
+
+  it('[DPT01] authorization_code + valid proof: binds the access, stamps the refresh row, token_type DPoP', async () => {
+    const platform = fakePlatform();
+    await seedCode(platform, 'C-DP1');
+    const bound = [];
+    const handler = handleToken({
+      config: fakeConfig(),
+      platform,
+      bindAccessDpop: async (p) => { bound.push(p); },
+    });
+    const res = fakeRes();
+    await handler(tokenReq(codeBody('C-DP1'), await makeProof(key)), res);
+    assert.equal(res.statusCode, 200, JSON.stringify(res.body));
+    assert.equal(res.body.token_type, 'DPoP');
+    const jkt = computeJkt(key.publicJwk);
+    assert.deepEqual(bound, [{ userId: 'u-alice', username: 'alice', accessId: 'acc-u-alice', jkt }]);
+    const row = await getRefresh(platform, CORE_ID, res.body.refresh_token);
+    assert.equal(row.jkt, jkt);
+  });
+
+  it('[DPT02] an invalid proof fails BEFORE the grant: 400 invalid_dpop_proof, code not consumed', async () => {
+    const platform = fakePlatform();
+    await seedCode(platform, 'C-DP2');
+    const handler = handleToken({ config: fakeConfig(), platform, bindAccessDpop: async () => {} });
+    const res = fakeRes();
+    const proof = await makeProof(key);
+    const tampered = proof.slice(0, -4) + 'AAAA';
+    await handler(tokenReq(codeBody('C-DP2'), tampered), res);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.error, 'invalid_dpop_proof');
+    // The code survives — a Bearer exchange still works.
+    const res2 = fakeRes();
+    await handler(tokenReq(codeBody('C-DP2')), res2);
+    assert.equal(res2.statusCode, 200, JSON.stringify(res2.body));
+    assert.equal(res2.body.token_type, 'Bearer');
+  });
+
+  it('[DPT03] jti single-use: replaying the same proof is refused, nothing consumed', async () => {
+    const platform = fakePlatform();
+    await seedCode(platform, 'C-DP3');
+    const handler = handleToken({ config: fakeConfig(), platform, bindAccessDpop: async () => {} });
+    const proof = await makeProof(key);
+    const res1 = fakeRes();
+    await handler(tokenReq({ grant_type: 'authorization_code', code: 'C-MISSING', code_verifier: VERIFIER, client_id: 'myapp', redirect_uri: 'https://app.example/cb' }, proof), res1);
+    // First use burned the jti (the grant itself failed on the missing code).
+    const res2 = fakeRes();
+    await handler(tokenReq(codeBody('C-DP3'), proof), res2);
+    assert.equal(res2.statusCode, 400);
+    assert.equal(res2.body.error, 'invalid_dpop_proof');
+    // The seeded code is untouched by the replayed-proof refusal.
+    const res3 = fakeRes();
+    await handler(tokenReq(codeBody('C-DP3')), res3);
+    assert.equal(res3.statusCode, 200, JSON.stringify(res3.body));
+  });
+
+  it('[DPT04] DPoP requested but binding not wired: 500 server_error, code not consumed', async () => {
+    const platform = fakePlatform();
+    await seedCode(platform, 'C-DP4');
+    const handler = handleToken({ config: fakeConfig(), platform });
+    const res = fakeRes();
+    await handler(tokenReq(codeBody('C-DP4'), await makeProof(key)), res);
+    assert.equal(res.statusCode, 500);
+    assert.equal(res.body.error, 'server_error');
+    const res2 = fakeRes();
+    await handler(tokenReq(codeBody('C-DP4')), res2);
+    assert.equal(res2.statusCode, 200, JSON.stringify(res2.body));
+  });
+
+  it('[DPT05] bound refresh + proof by the same key: rotates, keeps the binding, mint sees jkt', async () => {
+    const platform = fakePlatform();
+    const jkt = computeJkt(key.publicJwk);
+    await seedRefresh(platform, 'RT-DP5', { jkt });
+    const minted = [];
+    const handler = handleToken({
+      config: fakeConfig(),
+      platform,
+      mintRefreshedAccess: async (p) => { minted.push(p); return MINT_OK(); },
+    });
+    const res = fakeRes();
+    await handler(tokenReq({ grant_type: 'refresh_token', refresh_token: 'RT-DP5', client_id: 'myapp' }, await makeProof(key)), res);
+    assert.equal(res.statusCode, 200, JSON.stringify(res.body));
+    assert.equal(res.body.token_type, 'DPoP');
+    assert.equal(minted[0].jkt, jkt);
+    const newRow = await getRefresh(platform, CORE_ID, res.body.refresh_token);
+    assert.equal(newRow.jkt, jkt);
+  });
+
+  it('[DPT06] bound refresh WITHOUT a proof: refused (and the rotation is burned — safe direction)', async () => {
+    const platform = fakePlatform();
+    await seedRefresh(platform, 'RT-DP6', { jkt: computeJkt(key.publicJwk) });
+    const handler = handleToken({ config: fakeConfig(), platform, mintRefreshedAccess: MINT_OK });
+    const res = fakeRes();
+    await handler(tokenReq({ grant_type: 'refresh_token', refresh_token: 'RT-DP6', client_id: 'myapp' }), res);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.error, 'invalid_dpop_proof');
+    assert.equal(await getRefresh(platform, CORE_ID, 'RT-DP6'), null);
+  });
+
+  it('[DPT07] bound refresh with a proof by a DIFFERENT key: refused, uniform body', async () => {
+    const platform = fakePlatform();
+    await seedRefresh(platform, 'RT-DP7', { jkt: computeJkt(key.publicJwk) });
+    const otherKey = await makeKeyPair();
+    const handler = handleToken({ config: fakeConfig(), platform, mintRefreshedAccess: MINT_OK });
+    const res = fakeRes();
+    await handler(tokenReq({ grant_type: 'refresh_token', refresh_token: 'RT-DP7', client_id: 'myapp' }, await makeProof(otherKey)), res);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.error, 'invalid_dpop_proof');
+    assert.equal(res.body.error_description, 'DPoP proof verification failed');
+  });
+
+  it('[DPT08] an UNBOUND chain cannot acquire a binding mid-life', async () => {
+    const platform = fakePlatform();
+    await seedRefresh(platform, 'RT-DP8');
+    const handler = handleToken({ config: fakeConfig(), platform, mintRefreshedAccess: MINT_OK });
+    const res = fakeRes();
+    await handler(tokenReq({ grant_type: 'refresh_token', refresh_token: 'RT-DP8', client_id: 'myapp' }, await makeProof(key)), res);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.error, 'invalid_dpop_proof');
+  });
+
+  it('[DPT09] client_credentials with a proof is refused explicitly', async () => {
+    const platform = fakePlatform();
+    const handler = handleToken({
+      config: fakeConfig(),
+      platform,
+      mintClientAccess: MINT_OK,
+      resolveAccountUserId: async () => 'u-app',
+    });
+    const res = fakeRes();
+    await handler(tokenReq({ grant_type: 'client_credentials', client_id: 'myapp' }, await makeProof(key)), res);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.error, 'invalid_request');
+    assert.match(res.body.error_description, /client_credentials/);
+  });
+
+  it('[DPT10] a proof signed for another endpoint (htu mismatch) is refused', async () => {
+    const platform = fakePlatform();
+    await seedCode(platform, 'C-DP10');
+    const handler = handleToken({ config: fakeConfig(), platform, bindAccessDpop: async () => {} });
+    const res = fakeRes();
+    await handler(tokenReq(codeBody('C-DP10'), await makeProof(key, { htu: 'https://other.example/oauth2/token' })), res);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.error, 'invalid_dpop_proof');
+  });
+
+  it('[DPT11] a failing bindAccessDpop refuses issuance with 500 (no half-bound chain)', async () => {
+    const platform = fakePlatform();
+    await seedCode(platform, 'C-DP11');
+    const handler = handleToken({
+      config: fakeConfig(),
+      platform,
+      bindAccessDpop: async () => { throw new Error('storage down'); },
+    });
+    const res = fakeRes();
+    await handler(tokenReq(codeBody('C-DP11'), await makeProof(key)), res);
+    assert.equal(res.statusCode, 500);
+    assert.equal(res.body.error, 'server_error');
+  });
+});

--- a/components/oauth2/test/wellKnown.test.js
+++ b/components/oauth2/test/wellKnown.test.js
@@ -29,6 +29,7 @@ describe('[OAUTH-WK] discovery document', () => {
       assert.deepEqual(doc.grant_types_supported, ['authorization_code']);
       assert.deepEqual(doc.code_challenge_methods_supported, ['S256']);
       assert.equal(doc.authorization_response_iss_parameter_supported, true);
+      assert.deepEqual(doc.dpop_signing_alg_values_supported, ['ES256']);
     });
     it('[OAUTH-WK-1b] trims trailing slash on issuer', () => {
       const doc = buildDiscoveryDocument({

--- a/components/platform/test/conformance/PlatformDB.test.js
+++ b/components/platform/test/conformance/PlatformDB.test.js
@@ -575,7 +575,7 @@ export default function conformanceTests (getDB) {
       });
     });
 
-    describe('[ACCESSSTATE] setAccessState / getAccessState / deleteAccessState / sweepExpiredAccessStates', () => {
+    describe('[ACCESSSTATE] setAccessState / setAccessStateIfAbsent / getAccessState / deleteAccessState / sweepExpiredAccessStates', () => {
       const future = () => Date.now() + 60_000;
       const past = () => Date.now() - 1_000;
 
@@ -656,6 +656,44 @@ export default function conformanceTests (getDB) {
         assert.strictEqual(winners.length, 1, 'exactly one concurrent consumer wins');
         assert.deepStrictEqual(winners[0].value, value);
         assert.strictEqual(await db.getAccessState(key), null);
+      });
+
+      it('[AS12] setIfAbsent installs on a missing key and returns true', async () => {
+        const key = 'k-' + cuid();
+        const value = { jti: 'first' };
+        const expiresAt = future();
+        assert.strictEqual(await db.setAccessStateIfAbsent(key, value, expiresAt), true);
+        const got = await db.getAccessState(key);
+        assert.deepStrictEqual(got.value, value);
+        assert.strictEqual(got.expiresAt, expiresAt);
+      });
+
+      it('[AS13] setIfAbsent returns false on a live key and leaves the value untouched', async () => {
+        const key = 'k-' + cuid();
+        await db.setAccessState(key, { v: 1 }, future());
+        assert.strictEqual(await db.setAccessStateIfAbsent(key, { v: 2 }, future()), false);
+        assert.deepStrictEqual((await db.getAccessState(key)).value, { v: 1 });
+      });
+
+      it('[AS14] setIfAbsent reclaims an expired row and returns true', async () => {
+        const key = 'k-' + cuid();
+        await db.setAccessState(key, { v: 1 }, past());
+        assert.strictEqual(await db.setAccessStateIfAbsent(key, { v: 2 }, future()), true);
+        assert.deepStrictEqual((await db.getAccessState(key)).value, { v: 2 });
+      });
+
+      it('[AS15] concurrent setIfAbsent of one key: EXACTLY ONE winner (atomic first-writer-wins)', async () => {
+        // The security-critical guarantee for replay markers: two identical
+        // single-use proofs submitted at once must not both pass. Fire N
+        // set-if-absent calls at once; exactly one reports true.
+        const key = 'k-' + cuid();
+        const N = 8;
+        const results = await Promise.all(
+          Array.from({ length: N }, (_, i) => db.setAccessStateIfAbsent(key, { i }, future()))
+        );
+        const winners = results.filter((r) => r === true);
+        assert.strictEqual(winners.length, 1, 'exactly one concurrent caller wins');
+        assert.ok((await db.getAccessState(key)) != null);
       });
 
       it('[AS07] sweepExpiredAccessStates removes only expired rows and reports count', async () => {

--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -533,6 +533,18 @@ oauth:
   # DPoP (RFC 9449) sender-constrained tokens: acceptance window for a
   # proof's iat around server time. The feature itself needs no enable
   # flag — it is inert unless a client sends a DPoP header.
+  #
+  # ⚠️ DEPLOYMENT REQUIREMENT: a DPoP proof binds to the CLIENT-FACING
+  # request URI (method + scheme + host + path). The server reconstructs
+  # that URI from the X-Forwarded-Host / X-Forwarded-Proto headers,
+  # falling back to the connection's own host/proto. So any deployment
+  # that accepts DPoP MUST sit behind a reverse proxy that OVERWRITES
+  # (not appends to) these headers with the true client-facing values —
+  # otherwise a client could spoof X-Forwarded-Host to satisfy a proof
+  # minted for another host, and a proxy that omits X-Forwarded-Proto on
+  # a TLS-terminated connection makes every proof's https scheme mismatch
+  # (legitimate clients get 403). This is the same trusted-proxy posture
+  # already required for correct client-IP and rate-limit attribution.
   dpop:
     clockSkewSeconds: 120          # seconds (± around now)
   clientRegistration:

--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -530,6 +530,11 @@ oauth:
   # a replay past it revokes the whole chain. Keep small — real client retries are
   # sub-second. 0 = strict (any replay revokes).
   refreshReuseGraceSeconds: 10     # seconds
+  # DPoP (RFC 9449) sender-constrained tokens: acceptance window for a
+  # proof's iat around server time. The feature itself needs no enable
+  # flag — it is inert unless a client sends a DPoP header.
+  dpop:
+    clockSkewSeconds: 120          # seconds (± around now)
   clientRegistration:
     mode: curated                  # ONLY supported value; "open" is rejected
   requireAppAccountMfa: true       # app accounts must enrol MFA before /oauth2/* writes

--- a/storages/engines/postgresql/src/DBpostgresql.ts
+++ b/storages/engines/postgresql/src/DBpostgresql.ts
@@ -350,6 +350,24 @@ class DBpostgresql {
     await this.#set(getAccessStateKey(key), JSON.stringify({ value, expiresAt }));
   }
 
+  /**
+   * Atomic set-if-absent. A single upsert whose DO-UPDATE clause only
+   * fires on rows already past their expiresAt: the INSERT wins on a
+   * missing key, the conditional UPDATE reclaims an expired row, and a
+   * live row leaves rowCount at 0 — so of N concurrent callers exactly
+   * ONE reports true. Access-state payloads are always JSON written by
+   * this class, so the ::jsonb cast on the conflicting row is safe.
+   */
+  async setAccessStateIfAbsent (key: string, value: unknown, expiresAt: number): Promise<boolean> {
+    const res = await this.db.query(
+      `INSERT INTO platform_kv (key, value) VALUES ($1, $2)
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+       WHERE ((platform_kv.value)::jsonb ->> 'expiresAt')::numeric < $3`,
+      [getAccessStateKey(key), JSON.stringify({ value, expiresAt }), Date.now()]
+    );
+    return (res.rowCount ?? 0) > 0;
+  }
+
   async getAccessState (key: string): Promise<{ value: unknown, expiresAt: number } | null> {
     const storeKey = getAccessStateKey(key);
     const raw = await this.#get(storeKey);

--- a/storages/engines/rqlite/src/DBrqlite.ts
+++ b/storages/engines/rqlite/src/DBrqlite.ts
@@ -468,6 +468,26 @@ class DBrqlite {
     );
   }
 
+  /**
+   * Atomic set-if-absent. A single upsert whose DO-UPDATE clause only
+   * fires on rows already past their expiresAt: the INSERT wins on a
+   * missing key, the conditional UPDATE reclaims an expired row, and a
+   * live row leaves changes at 0. rqlite linearizes writes through
+   * Raft, so of N concurrent callers exactly ONE reports true.
+   * A conflicting row whose payload lacks a numeric expiresAt is
+   * treated as live (the WHERE is NULL) — the sweep cleans those up.
+   */
+  async setAccessStateIfAbsent (key: string, value: unknown, expiresAt: number): Promise<boolean> {
+    const storeKey = getAccessStateKey(key);
+    const result = await this.execute(
+      `INSERT INTO keyValue (key, value) VALUES (?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value
+       WHERE CAST(json_extract(keyValue.value, '$.expiresAt') AS INTEGER) < ?`,
+      [storeKey, JSON.stringify({ value, expiresAt }), Date.now()]
+    );
+    return (result?.rows_affected ?? 0) > 0;
+  }
+
   async getAccessState (key: string) {
     const storeKey = getAccessStateKey(key);
     const rows = await this.query('SELECT value FROM keyValue WHERE key = ?', [storeKey]);

--- a/storages/interfaces/platformStorage/PlatformDB.ts
+++ b/storages/interfaces/platformStorage/PlatformDB.ts
@@ -143,6 +143,17 @@ export interface PlatformDB {
 
   // --- Access-request state (cluster-wide ephemeral) --------------
   setAccessState (key: string, value: unknown, expiresAt: number): Promise<void>;
+  /**
+   * ATOMIC set-if-absent: install the value ONLY when no live entry
+   * holds the key, in one linearized operation. Returns true when this
+   * call installed the value (key absent, or held only an expired
+   * entry — expired rows count as absent and are replaced), false when
+   * a live entry exists (left untouched). Concurrent callers of the
+   * same key: exactly ONE gets true. Use this (not getAccessState +
+   * setAccessState, which races) for first-writer-wins state such as
+   * single-use nonce/replay markers.
+   */
+  setAccessStateIfAbsent (key: string, value: unknown, expiresAt: number): Promise<boolean>;
   getAccessState (key: string): Promise<AccessStateEntry | null>;
   deleteAccessState (key: string): Promise<void>;
   /**
@@ -276,6 +287,8 @@ const PlatformDB: PlatformDB = {
   // --- Access-request state --- //
 
   async setAccessState (key: string, value: unknown, expiresAt: number): Promise<void> { throw new Error('Not implemented'); },
+
+  async setAccessStateIfAbsent (key: string, value: unknown, expiresAt: number): Promise<boolean> { throw new Error('Not implemented'); },
 
   async getAccessState (key: string): Promise<AccessStateEntry | null> { throw new Error('Not implemented'); },
 


### PR DESCRIPTION
Adds RFC 9449 DPoP sender-constrained tokens to the OAuth2 authorization
server. A client that opts in presents a per-request proof (a JWS signed
with a client-held key); the token endpoint binds issued tokens to the
key's RFC 7638 thumbprint, and the resource server rejects any request
whose proof doesn't match. A stolen DPoP token is useless without the
private key. The Bearer path is untouched (opt-in), and tokens stay
opaque CUID2.

## Design decisions
- **ES256 only** in v1 (universal WebCrypto fit; EdDSA on demand).
- **Dependency-free verifier** — `node:crypto` webcrypto verify + RFC 7638
  thumbprint; the server never signs, so no new production dependency.
- **No server-issued `DPoP-Nonce`** in v1 — the atomic single-use `jti`
  cache + `iat` skew window cover the threat model; adding it later is
  additive.
- **120 s clock-skew default**, `oauth.dpop.clockSkewSeconds`.

## What's in each commit
1. **platform** — atomic `setAccessStateIfAbsent` (rqlite + PG, conformance
   tests incl. a concurrent-race test). The jti replay cache needs a real
   first-writer-wins primitive; the plain upsert would double-spend.
2. **verifier** (`oauth2/src/dpop.ts`) — JWS parse, `typ`/`alg` pinning
   (no alg-confusion surface), public-EC-P-256 sanitization, claim checks
   (`htm`/`htu` normalized per §4.3, `iat`, `jti`, `ath`), thumbprint.
3. **token endpoint** — verify-before-any-grant + atomic jti burn; bind the
   pre-minted authorization-code access via a storage-direct seam; refresh
   rotation requires a proof by the same key and inherits the binding;
   `token_type: DPoP`.
4. **resource server** — enforcement at the shared `retrieveExpandedAccess`
   choke point, so a bound token presented over socket.io / hfs / previews
   (which carry no proof) fails closed by construction. DPoP auth-scheme
   recognized in `MethodContext` (batch route included); htu reconstructed
   from the client-facing URI ahead of the internal rewrites;
   `WWW-Authenticate: DPoP` challenges; an `accesses.update` anti-downgrade
   guard (the update replaces `clientData` wholesale).
5. **discovery + e2e** — `dpop_signing_alg_values_supported` + a full
   sender-constrained round-trip.
6. **review fixes** — trusted-proxy deployment doc; a validated file
   `readToken` exempts the attachment-download path (a `<img>`/download GET
   can't carry a proof, and the HMAC is itself a per-file possession proof;
   scoped to attachment reads only); `accesses.create` anti-forge guard;
   `oauth.token.dpop_mismatch` audit event.

## Security review
Reviewed adversarially (jti replay across both burn sites, upsert
atomicity on both engines, htu spoofing, anti-downgrade completeness,
fail-open enumeration across every access-load entry point, alg/key
confusion). No CRITICAL/HIGH, no bypass, no double-spend, no fail-open.
All findings were LOW/hardening and are addressed in commit 6 (or, for the
deployment posture, documented).

## Validation
- oauth2 unit **305** (14 `[DPV]` verifier + 11 `[DPT]` token-binding) ·
  audit **53** · business **454** · resource-server enforcement **12**
  `[DPN]` · OAuth e2e **22** (incl. `[OE21DP]`/`[OE22DP]` round-trip)
- Full **PostgreSQL** matrix and full **SQLite** matrix — DPoP-clean on
  both engines (remaining reds are an unrelated in-progress feature's
  tests-first suite + one known environmental flake, both reproduced off
  this branch)
- typecheck + all lint gates (create-require ratchet, prod-dep-integrity,
  no-explicit-any) + published-repo hygiene

## Not in this PR (follow-up, separately gated)
Client support (lib-js `SignedConnection` + `OAuth2Client({dpop:true})`),
the app-account public-key inventory, and operator revoke-by-key-thumbprint
— those pair with the cluster revoke-fan-out work.
